### PR TITLE
18 bug gradle 34

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,16 @@ Once you have a bunch of screenshot tests recorded you can easily verify if the 
 ![shotTasksHelp](./art/tasksDescription.png)
 
 [karumilogo]: https://cloud.githubusercontent.com/assets/858090/11626547/e5a1dc66-9ce3-11e5-908d-537e07e82090.png
+
+## Know Issues
+
+If you include in your project a dependency to dexmaker or a library that contains a dependency to dexmaker is possible that you have an Exception ``com.android.dx.util.DexException: Multiple dex files define``. For resolve this bug you only need to include de Facebook library in your own project excluding the dexmaker libs:
+
+ ```
+   androidTestCompile ('com.facebook.testing.screenshot:core:0.4.2') {
+     exclude group: 'com.crittercism.dexmaker', module: 'dexmaker'
+     exclude group: 'com.crittercism.dexmaker', module: 'dexmaker-dx'
+   }
+ ```
+ 
+ Shot plugin autodetect if you are including screenshot facebook library in you gradle and if this is present does not include again.

--- a/core/src/main/scala/com/karumi/shot/domain/model.scala
+++ b/core/src/main/scala/com/karumi/shot/domain/model.scala
@@ -1,10 +1,6 @@
 package com.karumi.shot.domain
 
-import com.karumi.shot.domain.model.{
-  FilePath,
-  ScreenshotComparisionErrors,
-  ScreenshotsSuite
-}
+import com.karumi.shot.domain.model.{FilePath, ScreenshotComparisionErrors, ScreenshotsSuite}
 
 object model {
   type ScreenshotsSuite = Seq[Screenshot]
@@ -15,9 +11,12 @@ object model {
 }
 
 object Config {
-  val androidDependencyMode: FilePath = "androidTestCompile"
-  val androidDependency: FilePath =
-    "com.facebook.testing.screenshot:core:0.4.2"
+  val androidDependencyModeLegacy: FilePath = "androidTestCompile"
+  val androidDependencyMode: FilePath = "androidTestImplementation"
+  val androidDependencyGroup: String = "com.facebook.testing.screenshot"
+  val androidDependencyName: String = "core"
+  val androidDependencyVersion: String = "0.4.2"
+  val androidDependency: FilePath = s"$androidDependencyGroup:$androidDependencyName:$androidDependencyVersion"
   val screenshotsFolderName: FilePath = "/screenshots/"
   val pulledScreenshotsFolder
     : FilePath = screenshotsFolderName + "screenshots-default/"

--- a/core/src/main/scala/com/karumi/shot/domain/model.scala
+++ b/core/src/main/scala/com/karumi/shot/domain/model.scala
@@ -1,6 +1,10 @@
 package com.karumi.shot.domain
 
-import com.karumi.shot.domain.model.{FilePath, ScreenshotComparisionErrors, ScreenshotsSuite}
+import com.karumi.shot.domain.model.{
+  FilePath,
+  ScreenshotComparisionErrors,
+  ScreenshotsSuite
+}
 
 object model {
   type ScreenshotsSuite = Seq[Screenshot]
@@ -16,7 +20,8 @@ object Config {
   val androidDependencyGroup: String = "com.facebook.testing.screenshot"
   val androidDependencyName: String = "core"
   val androidDependencyVersion: String = "0.4.2"
-  val androidDependency: FilePath = s"$androidDependencyGroup:$androidDependencyName:$androidDependencyVersion"
+  val androidDependency: FilePath =
+    s"$androidDependencyGroup:$androidDependencyName:$androidDependencyVersion"
   val screenshotsFolderName: FilePath = "/screenshots/"
   val pulledScreenshotsFolder
     : FilePath = screenshotsFolderName + "screenshots-default/"

--- a/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
@@ -9,7 +9,11 @@ class ConfigSpec extends FlatSpec with Matchers {
   }
 
   it should "add the dependency using the androidTestCompile mode" in {
-    Config.androidDependencyMode shouldBe "androidTestCompile"
+    Config.androidDependencyModeLegacy shouldBe "androidTestCompile"
+  }
+
+  it should "add the dependency using the androidTestImplementation mode" in {
+    Config.androidDependencyMode shouldBe "androidTestImplementation"
   }
 
   it should "save the screenshots into the screenshots folder" in {

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -3,29 +3,32 @@ package com.karumi.shot
 import com.karumi.shot.android.Adb
 import com.karumi.shot.domain.Config
 import com.karumi.shot.screenshots.{ScreenshotsComparator, ScreenshotsSaver}
-import com.karumi.shot.tasks.{
-  RemoveScreenshotsTask,
-  ExecuteScreenshotTests,
-  DownloadScreenshotsTask
-}
+import com.karumi.shot.tasks.{DownloadScreenshotsTask, ExecuteScreenshotTests, RemoveScreenshotsTask}
 import com.karumi.shot.ui.Console
+import org.gradle.api.artifacts.{Dependency, DependencyResolutionListener, ResolvableDependencies}
 import org.gradle.api.{Plugin, Project}
+import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.model.build.BuildEnvironment
 
 class ShotPlugin extends Plugin[Project] {
 
+  def GRADLE_MIN_MAJOR = 3
+  def GRADLE_MIN_MINOR = 4
+
   private lazy val shot: Shot =
     new Shot(new Adb,
-             new Files,
-             new ScreenshotsComparator,
-             new ScreenshotsSaver,
-             new Console)
+      new Files,
+      new ScreenshotsComparator,
+      new ScreenshotsSaver,
+      new Console)
 
   override def apply(project: Project): Unit = {
     configureAdb(project)
-    addAndroidTestDependency(project)
     addExtensions(project)
-    project.afterEvaluate { project =>
+    addAndroidTestDependency(project)
+    project.afterEvaluate { project => {
       addTasks(project)
+    }
     }
   }
 
@@ -34,14 +37,6 @@ class ShotPlugin extends Plugin[Project] {
     shot.configureAdbPath(adbPath)
   }
 
-  private def addAndroidTestDependency(project: Project): Unit = {
-    val dependencyMode = Config.androidDependencyMode
-    val dependencyName = Config.androidDependency
-    val dependenciesHandler = project.getDependencies
-    val dependency = dependenciesHandler.create(dependencyName)
-    Option(project.getPlugins.findPlugin(Config.androidPluginName))
-      .map(_ => dependenciesHandler.add(dependencyMode, dependency))
-  }
 
   private def addTasks(project: Project): Unit = {
     project.getTasks
@@ -72,4 +67,72 @@ class ShotPlugin extends Plugin[Project] {
     project.getExtensions.add(name, new ShotExtension())
   }
 
+
+  private def isLegacyGradleVersion(gradleVersion: String): Boolean = {
+    val versionNumbers = gradleVersion.split('.')
+    var major = 0
+    var minor = 0
+
+    if (versionNumbers.length > 0) {
+      major = versionNumbers(0).toInt
+    }
+    if (versionNumbers.length > 1) {
+      minor = versionNumbers(1).toInt
+    }
+
+    (major, minor) match {
+      case (major, _) if major > GRADLE_MIN_MAJOR => false
+      case (major, minor) if major == GRADLE_MIN_MAJOR && minor >= GRADLE_MIN_MINOR => false
+      case _ => true
+    }
+
+  }
+
+  private def androidDependencyMode(project: Project): String = {
+    val connection = GradleConnector.newConnector.forProjectDirectory(project.getProjectDir).connect
+
+    try {
+      val gradleVersion = connection.getModel(classOf[BuildEnvironment]).getGradle.getGradleVersion
+
+      if (isLegacyGradleVersion(gradleVersion)) {
+        return Config.androidDependencyModeLegacy
+      }
+
+    } finally connection.close()
+
+    Config.androidDependencyMode
+  }
+
+  private def addAndroidTestDependency(project: Project): Unit = {
+
+    project.getGradle.addListener(new DependencyResolutionListener() {
+
+
+      override def beforeResolve(resolvableDependencies: ResolvableDependencies): Unit = {
+        var facebookDependencyHasBeenAdded = false
+
+        project.getConfigurations.forEach(
+          config => {
+            facebookDependencyHasBeenAdded |= config.getAllDependencies.toArray(new Array[Dependency](0)).exists(
+              dependency =>
+                Config.androidDependencyGroup == dependency.getGroup
+                  && Config.androidDependencyName == dependency.getName)
+          })
+
+
+        if (!facebookDependencyHasBeenAdded) {
+          val dependencyMode = androidDependencyMode(project)
+          val dependencyName = Config.androidDependency
+          val dependenciesHandler = project.getDependencies
+
+          val dependencyToAdd = dependenciesHandler.create(dependencyName)
+          Option(project.getPlugins.findPlugin(Config.androidPluginName))
+            .map(_ => project.getDependencies.add(dependencyMode, dependencyToAdd))
+          project.getGradle.removeListener(this)
+        }
+      }
+
+      override def afterResolve(resolvableDependencies: ResolvableDependencies): Unit = {}
+    })
+  }
 }

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -18,10 +18,12 @@ import org.gradle.api.{Plugin, Project}
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.model.build.BuildEnvironment
 
-class ShotPlugin extends Plugin[Project] {
+object ShotPlugin {
+  private val minGradleVersionSupportedMajorNumber = 3
+  private val minGradleVersionSupportedMinorNumber = 4
+}
 
-  def GRADLE_MIN_MAJOR = 3
-  def GRADLE_MIN_MINOR = 4
+class ShotPlugin extends Plugin[Project] {
 
   private lazy val shot: Shot =
     new Shot(new Adb,
@@ -88,9 +90,12 @@ class ShotPlugin extends Plugin[Project] {
     }
 
     (major, minor) match {
-      case (major, _) if major > GRADLE_MIN_MAJOR => false
+      case (major, _)
+          if major > ShotPlugin.minGradleVersionSupportedMajorNumber =>
+        false
       case (major, minor)
-          if major == GRADLE_MIN_MAJOR && minor >= GRADLE_MIN_MINOR =>
+          if major == ShotPlugin.minGradleVersionSupportedMajorNumber
+            && minor >= ShotPlugin.minGradleVersionSupportedMinorNumber =>
         false
       case _ => true
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://github.com/Karumi/Shot/issues/18

### :tophat: What is the goal?

The objective for this PR is to fix two problems:

1) Adjust gradle compile mode to the new gradle compile mode required by new gradle versions and giving support for the old one. To do this we will detect the gradle version and modify compile for implementation.

2) Fix a problem with an exception in the dex when including a library that contains a reference to dexmaker.

### How is it being implemented?

I added a new method that detects the gradle versión and provides implementationAndroidTest or compileAndroidTest depends on the version.

I change the way that adds the facebook library moving the include of the library when the dependencies tree is going to be processed, search if the Facebook dependency exists in the project and include it if this is missing.

### How can it be tested?

1) Create a project
2) Include a library that contains a different version of the Facebook dexmaker, and compile. If the plugin is not working correctly must throw a dex exception. If this PR works must work perfectly.
