### PR TITLE
Update facebook dependency to 0.8.0

### DIFF
--- a/core/src/main/scala/com/karumi/shot/domain/model.scala
+++ b/core/src/main/scala/com/karumi/shot/domain/model.scala
@@ -19,7 +19,7 @@ object Config {
   val androidDependencyMode: FilePath = "androidTestImplementation"
   val androidDependencyGroup: String = "com.facebook.testing.screenshot"
   val androidDependencyName: String = "core"
-  val androidDependencyVersion: String = "0.6.0"
+  val androidDependencyVersion: String = "0.8.0"
   val androidDependency: FilePath =
     s"$androidDependencyGroup:$androidDependencyName:$androidDependencyVersion"
   val screenshotsFolderName: FilePath = "/screenshots/"

--- a/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class ConfigSpec extends FlatSpec with Matchers {
 
   "Config" should "use the screenshot tests library implemented by Facebook" in {
-    Config.androidDependency shouldBe "com.facebook.testing.screenshot:core:0.6.0"
+    Config.androidDependency shouldBe "com.facebook.testing.screenshot:core:0.8.0"
   }
 
   it should "add the dependency using the androidTestCompile mode" in {

--- a/shot-consumer/app/build.gradle
+++ b/shot-consumer/app/build.gradle
@@ -14,12 +14,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'shot'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion '26.0.2'
+  compileSdkVersion 28
+  buildToolsVersion '28.0.2'
   defaultConfig {
     applicationId 'com.karumi.screenshot'
     minSdkVersion 16
-    targetSdkVersion 23
+    targetSdkVersion 28
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner 'com.karumi.screenshot.ScreenshotTestRunner'
@@ -40,8 +40,8 @@ android {
 
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
-  implementation 'com.android.support:appcompat-v7:23.1.1'
-  implementation 'com.android.support:design:23.1.1'
+  implementation 'com.android.support:appcompat-v7:28.0.0'
+  implementation 'com.android.support:design:28.0.0'
   implementation 'com.squareup.picasso:picasso:2.5.2'
   implementation 'com.jakewharton:butterknife:7.0.1'
   implementation 'com.google.dagger:dagger:2.0.2'

--- a/shot-consumer/app/build.gradle
+++ b/shot-consumer/app/build.gradle
@@ -14,12 +14,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'shot'
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.2'
+  compileSdkVersion 23
+  buildToolsVersion '26.0.2'
   defaultConfig {
     applicationId 'com.karumi.screenshot'
     minSdkVersion 16
-    targetSdkVersion 28
+    targetSdkVersion 23
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner 'com.karumi.screenshot.ScreenshotTestRunner'
@@ -40,8 +40,8 @@ android {
 
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
-  implementation 'com.android.support:appcompat-v7:28.0.0'
-  implementation 'com.android.support:design:28.0.0'
+  implementation 'com.android.support:appcompat-v7:23.1.1'
+  implementation 'com.android.support:design:23.1.1'
   implementation 'com.squareup.picasso:picasso:2.5.2'
   implementation 'com.jakewharton:butterknife:7.0.1'
   implementation 'com.google.dagger:dagger:2.0.2'

--- a/shot-consumer/app/src/androidTest/java/com/karumi/screenshot/ScreenshotTest.java
+++ b/shot-consumer/app/src/androidTest/java/com/karumi/screenshot/ScreenshotTest.java
@@ -19,16 +19,16 @@ package com.karumi.screenshot;
 import android.app.Activity;
 import android.content.Context;
 import android.support.v7.widget.RecyclerView;
-import android.test.suitebuilder.annotation.LargeTest;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.WindowManager;
+
 import com.facebook.testing.screenshot.Screenshot;
 import com.facebook.testing.screenshot.ViewHelpers;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
-@LargeTest public class ScreenshotTest {
+public class ScreenshotTest {
 
   protected void compareScreenshot(Activity activity) {
     Screenshot.snapActivity(activity).record();

--- a/shot-consumer/build.gradle
+++ b/shot-consumer/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
+    classpath 'com.android.tools.build:gradle:3.2.0'
   }
 }
 
@@ -12,6 +12,7 @@ allprojects {
   repositories {
     jcenter()
     maven { url "https://jitpack.io" }
+      google()
   }
 
   apply plugin: 'checkstyle'

--- a/shot-consumer/build.gradle
+++ b/shot-consumer/build.gradle
@@ -12,7 +12,7 @@ allprojects {
   repositories {
     jcenter()
     maven { url "https://jitpack.io" }
-      google()
+    google()
   }
 
   apply plugin: 'checkstyle'

--- a/shot-consumer/gradle/wrapper/gradle-wrapper.properties
+++ b/shot-consumer/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 06 19:32:36 CET 2018
+#Mon Oct 01 13:49:06 BRT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #42 

### :tophat: What is the goal?
* To increment facebook screenshot testing library to 0.8.0
* To upgrade android support library to 28

### How is it being implemented?
* Increase facebook library version to 0.8.0
* Increase android support library to 28

### How can it be tested?
* Start a new emulator
* Run './gradlew executeScreenshotTests -Precord'
* Run './gradlew executeScreenshotTests' 
And check if everything works properly


