### PR TITLE
Use only androidTestImplementation

### DIFF
--- a/core/src/main/scala/com/karumi/shot/domain/model.scala
+++ b/core/src/main/scala/com/karumi/shot/domain/model.scala
@@ -15,7 +15,6 @@ object model {
 }
 
 object Config {
-  val androidDependencyModeLegacy: FilePath = "androidTestCompile"
   val androidDependencyMode: FilePath = "androidTestImplementation"
   val androidDependencyGroup: String = "com.facebook.testing.screenshot"
   val androidDependencyName: String = "core"

--- a/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
@@ -8,10 +8,6 @@ class ConfigSpec extends FlatSpec with Matchers {
     Config.androidDependency shouldBe "com.facebook.testing.screenshot:core:0.8.0"
   }
 
-  it should "add the dependency using the androidTestCompile mode" in {
-    Config.androidDependencyModeLegacy shouldBe "androidTestCompile"
-  }
-
   it should "add the dependency using the androidTestImplementation mode" in {
     Config.androidDependencyMode shouldBe "androidTestImplementation"
   }

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -89,51 +89,6 @@ class ShotPlugin extends Plugin[Project] {
     project.getExtensions.add(name, new ShotExtension())
   }
 
-  private def isLegacyGradleVersion(gradleVersion: String): Boolean = {
-    val versionNumbers = gradleVersion.split('.')
-    var major = 0
-    var minor = 0
-
-    if (versionNumbers.length > 0) {
-      major = versionNumbers(0).toInt
-    }
-    if (versionNumbers.length > 1) {
-      minor = versionNumbers(1).toInt
-    }
-
-    (major, minor) match {
-      case (major, _)
-          if major > ShotPlugin.minGradleVersionSupportedMajorNumber =>
-        false
-      case (major, minor)
-          if major == ShotPlugin.minGradleVersionSupportedMajorNumber
-            && minor >= ShotPlugin.minGradleVersionSupportedMinorNumber =>
-        false
-      case _ => true
-    }
-
-  }
-
-  private def androidDependencyMode(project: Project): String = {
-    val connection = GradleConnector.newConnector
-      .forProjectDirectory(project.getProjectDir)
-      .connect
-
-    try {
-      val gradleVersion = connection
-        .getModel(classOf[BuildEnvironment])
-        .getGradle
-        .getGradleVersion
-
-      if (isLegacyGradleVersion(gradleVersion)) {
-        return Config.androidDependencyModeLegacy
-      }
-
-    } finally connection.close()
-
-    Config.androidDependencyMode
-  }
-
   private def addAndroidTestDependency(project: Project): Unit = {
 
     project.getGradle.addListener(new DependencyResolutionListener() {
@@ -153,7 +108,7 @@ class ShotPlugin extends Plugin[Project] {
         })
 
         if (!facebookDependencyHasBeenAdded) {
-          val dependencyMode = androidDependencyMode(project)
+          val dependencyMode = Config.androidDependencyMode
           val dependencyName = Config.androidDependency
           val dependenciesHandler = project.getDependencies
 


### PR DESCRIPTION
### :tophat: What is the goal?

Fixes #48 . Use only ``androidTestImplementation`` instead of ``testImplementation`` because we've noticed this is not working properly on the latest project we've been working on.

### How is it being implemented?

We've removed the old code and the coverage associated.

### How can it be tested?

🤖 