### PR TITLE
Enable executing screenshot task without running instrumentation

### DIFF
--- a/shot/src/main/scala/com/karumi/shot/ShotExtension.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotExtension.scala
@@ -8,9 +8,10 @@ object ShotExtension {
 
 class ShotExtension(@BeanProperty var appId: String,
                     @BeanProperty var instrumentationTestTask: String,
-                    @BeanProperty var packageTestApkTask: String) {
+                    @BeanProperty var packageTestApkTask: String,
+                    @BeanProperty var runInstrumentation: Boolean) {
 
-  def this() = this(null, null, null)
+  def this() = this(null, null, null, true)
 
   def getOptionAppId: Option[String] = Option(getAppId)
 

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -72,16 +72,19 @@ class ShotPlugin extends Plugin[Project] {
       project.getExtensions.getByType[ShotExtension](classOf[ShotExtension])
     val instrumentationTask = extension.getOptionInstrumentationTestTask
     val packageTask = extension.getOptionPackageTestApkTask
-    (instrumentationTask, packageTask) match {
-      case (Some(instTask), Some(packTask)) =>
-        executeScreenshot.dependsOn(instTask)
-        pullScreenshots.dependsOn(packTask)
-      case _ =>
-        executeScreenshot.dependsOn(Config.defaultInstrumentationTestTask)
-        pullScreenshots.dependsOn(Config.defaultPackageTestApkTask)
-    }
 
-    executeScreenshot.dependsOn(DownloadScreenshotsTask.name)
+    if (extension.runInstrumentation) {
+      (instrumentationTask, packageTask) match {
+        case (Some(instTask), Some(packTask)) =>
+          executeScreenshot.dependsOn(instTask)
+          pullScreenshots.dependsOn(packTask)
+        case _ =>
+          executeScreenshot.dependsOn(Config.defaultInstrumentationTestTask)
+          pullScreenshots.dependsOn(Config.defaultPackageTestApkTask)
+      }
+
+      executeScreenshot.dependsOn(DownloadScreenshotsTask.name)
+    }
   }
 
   private def addExtensions(project: Project): Unit = {

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -61,18 +61,19 @@ class ShotPlugin extends Plugin[Project] {
   }
 
   private def addTasks(project: Project): Unit = {
+    val extension =
+      project.getExtensions.getByType[ShotExtension](classOf[ShotExtension])
     project.getTasks
       .create(RemoveScreenshotsTask.name, classOf[RemoveScreenshotsTask])
     val pullScreenshots = project.getTasks
       .create(DownloadScreenshotsTask.name, classOf[DownloadScreenshotsTask])
     val executeScreenshot = project.getTasks
       .create(ExecuteScreenshotTests.name, classOf[ExecuteScreenshotTests])
-    executeScreenshot.dependsOn(RemoveScreenshotsTask.name)
-    val extension =
-      project.getExtensions.getByType[ShotExtension](classOf[ShotExtension])
+    if (extension.runInstrumentation) {
+      executeScreenshot.dependsOn(RemoveScreenshotsTask.name)
+    }
     val instrumentationTask = extension.getOptionInstrumentationTestTask
     val packageTask = extension.getOptionPackageTestApkTask
-
     if (extension.runInstrumentation) {
       (instrumentationTask, packageTask) match {
         case (Some(instTask), Some(packTask)) =>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://github.com/Karumi/Shot/issues/49

### :tophat: What is the goal?

This allows you to integrate remote service such as Firebase Test Lab with screenshot reporting.

### How is it being implemented?
We provide a flag to disable instrumentation tests that run as part of screenshot task suite. 
```
shot {
  runInstrumentationTests = false
}
```

User can now instead provide screenshot data in **screenshots/screenshots-default** folder and just call **executeScreenshotTests**.

### How can it be tested?
- Add fake screenshot data to **shots-consumer/app/screenshots/screenshots-default** 
- Disable the `runInstrumentationTests` flag
- Run `executeScreenshotTests`