### PR TITLE
Fix configuration name to not run instrumentation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If for some reason you are running your tests on a different machine and you wan
 
 ```groovy
   shot {
-    runInstrumentationTests = false
+    runInstrumentation = false
   }
 ```
 


### PR DESCRIPTION
### :tophat: What is the goal

Update `README` file to reference the expected configuration name that is `runInstrumentation` not `runInstrumentationTests`