### PR TITLE
Add support for android gradle pluggin 3.5.0

### DIFF
--- a/shot-consumer/build.gradle
+++ b/shot-consumer/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url uri('../repo') }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.karumi:shot:3.0.2-SNAPSHOT'
     }

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -45,11 +45,11 @@ class ShotPlugin extends Plugin[Project] {
     )
 
   override def apply(project: Project): Unit = {
-    configureAdb(project)
     addExtensions(project)
     addAndroidTestDependency(project)
     project.afterEvaluate { project =>
       {
+        configureAdb(project)
         addTasks(project)
       }
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Fixes #63 

### :tophat: What is the goal?

Provide support for the Android Gradle Plugin 3.5.X

### How is it being implemented?

We've noticed the part of the gradle plugin asking for the adb path was initialized before the Android Gradle Plugin is un and running and this was breaking the build. We've moved the adb path configuration to a different plugin setup stage so we get this value once it's ready.

Additionally, we've updated the example project provided in this repository named ``shot-consumer`` to use the Android Gradle Plugin version 3.5.0 so we ensure this issue will never happen again.

### How can it be tested?

🤖 