### PR TITLE
Show failed tests first - they are of much higher interest.

### DIFF
--- a/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
@@ -117,7 +117,8 @@ class ExecutionReporter {
       .map { screenshot: Screenshot =>
         val error = findError(screenshot, comparison.errors)
         (screenshot, error)
-      }.sortBy(_._2.isEmpty)
+      }
+      .sortBy(_._2.isEmpty)
 
   private def generateVerificationSummaryTableBody(
       comparision: ScreenshotsComparisionResult): String = {

--- a/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
@@ -112,20 +112,12 @@ class ExecutionReporter {
   }
 
   private def getSortedByResultScreenshots(
-      comparison: ScreenshotsComparisionResult) = {
-    val errors = comparison.errors
-    val groupedByResult = comparison.screenshots
+      comparison: ScreenshotsComparisionResult) =
+    comparison.screenshots
       .map { screenshot: Screenshot =>
-        val error = findError(screenshot, errors)
+        val error = findError(screenshot, comparison.errors)
         (screenshot, error)
-      }
-      .groupBy {
-        case (screenshot, error) =>
-          val isFailedTest = error.isDefined
-          !isFailedTest
-      }
-    groupedByResult(false) ++ groupedByResult(true)
-  }
+      }.sortBy(_._2.isEmpty)
 
   private def generateVerificationSummaryTableBody(
       comparision: ScreenshotsComparisionResult): String = {

--- a/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
@@ -111,12 +111,24 @@ class ExecutionReporter {
         "screenshotsTableBody" -> screenshotsTableBody).asJava
   }
 
+  private def getSortedByResultScreenshots(comparison: ScreenshotsComparisionResult) = {
+    val errors = comparison.errors
+    val groupedByResult = comparison.screenshots
+    .map { screenshot: Screenshot =>
+        val error = findError(screenshot, errors)
+        (screenshot, error)
+      }
+    .groupBy { case (screenshot, error) =>
+      val isFailedTest = error.isDefined
+      !isFailedTest
+    }
+    groupedByResult(false) ++ groupedByResult(true)
+  }
+
   private def generateVerificationSummaryTableBody(
       comparision: ScreenshotsComparisionResult): String = {
-    val errors = comparision.errors
-    comparision.screenshots
-      .map { screenshot: Screenshot =>
-        val error = findError(screenshot, errors)
+    getSortedByResultScreenshots(comparision)
+      .map { case (screenshot, error) =>
         val isFailedTest = error.isDefined
         val testClass = screenshot.testClass
         val testName = screenshot.testName
@@ -136,10 +148,8 @@ class ExecutionReporter {
 
   private def generateScreenshotsTableBody(
       comparision: ScreenshotsComparisionResult): String = {
-    val errors = comparision.errors
-    comparision.screenshots
-      .map { screenshot: Screenshot =>
-        val error = findError(screenshot, errors)
+    getSortedByResultScreenshots(comparision)
+      .map { case (screenshot, error) =>
         val isFailedTest = error.isDefined
         val testClass = screenshot.testClass
         val testName = screenshot.testName

--- a/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
@@ -111,37 +111,40 @@ class ExecutionReporter {
         "screenshotsTableBody" -> screenshotsTableBody).asJava
   }
 
-  private def getSortedByResultScreenshots(comparison: ScreenshotsComparisionResult) = {
+  private def getSortedByResultScreenshots(
+      comparison: ScreenshotsComparisionResult) = {
     val errors = comparison.errors
     val groupedByResult = comparison.screenshots
-    .map { screenshot: Screenshot =>
+      .map { screenshot: Screenshot =>
         val error = findError(screenshot, errors)
         (screenshot, error)
       }
-    .groupBy { case (screenshot, error) =>
-      val isFailedTest = error.isDefined
-      !isFailedTest
-    }
+      .groupBy {
+        case (screenshot, error) =>
+          val isFailedTest = error.isDefined
+          !isFailedTest
+      }
     groupedByResult(false) ++ groupedByResult(true)
   }
 
   private def generateVerificationSummaryTableBody(
       comparision: ScreenshotsComparisionResult): String = {
     getSortedByResultScreenshots(comparision)
-      .map { case (screenshot, error) =>
-        val isFailedTest = error.isDefined
-        val testClass = screenshot.testClass
-        val testName = screenshot.testName
-        val result = if (isFailedTest) "❌" else "✅"
-        val reason = generateReasonMessage(error)
-        val color = if (isFailedTest) "red-text" else "green-text"
-        val id = screenshot.name.replace(".", "")
-        "<tr>" +
-          s"<th><a href='#$id'>$result</></th>" +
-          s"<th><a href='#$id'><p class='$color'>Test class: $testClass</p>" +
-          s"<p class='$color'>Test name: $testName</p></a></th>" +
-          s"<th>$reason</th>" +
-          "</tr>"
+      .map {
+        case (screenshot, error) =>
+          val isFailedTest = error.isDefined
+          val testClass = screenshot.testClass
+          val testName = screenshot.testName
+          val result = if (isFailedTest) "❌" else "✅"
+          val reason = generateReasonMessage(error)
+          val color = if (isFailedTest) "red-text" else "green-text"
+          val id = screenshot.name.replace(".", "")
+          "<tr>" +
+            s"<th><a href='#$id'>$result</></th>" +
+            s"<th><a href='#$id'><p class='$color'>Test class: $testClass</p>" +
+            s"<p class='$color'>Test name: $testName</p></a></th>" +
+            s"<th>$reason</th>" +
+            "</tr>"
       }
       .mkString("\n")
   }
@@ -149,27 +152,28 @@ class ExecutionReporter {
   private def generateScreenshotsTableBody(
       comparision: ScreenshotsComparisionResult): String = {
     getSortedByResultScreenshots(comparision)
-      .map { case (screenshot, error) =>
-        val isFailedTest = error.isDefined
-        val testClass = screenshot.testClass
-        val testName = screenshot.testName
-        val originalScreenshot = "./images/recorded/" + screenshot.name + ".png"
-        val newScreenshot = "./images/" + screenshot.name + ".png"
-        val diff = if (error.exists(_.isInstanceOf[DifferentScreenshots])) {
-          screenshot.getDiffScreenshotPath("./images/")
-        } else {
-          ""
-        }
-        val color = if (isFailedTest) "red-text" else "green-text"
-        val width = (screenshot.screenshotDimension.width * 0.2).toInt
-        val id = screenshot.name.replace(".", "")
-        "<tr>" +
-          s"<th id='$id'> <p class='$color'>Test class: $testClass</p>" +
-          s"<p class='$color'>Test name: $testName</p></th>" +
-          s"<th> <a href='$originalScreenshot'><img width='$width' src='$originalScreenshot'/></a></th>" +
-          s"<th> <a href='$newScreenshot'><img width='$width' src='$newScreenshot'/></a></th>" +
-          s"<th> <a href='$diff'><img width='$width' src='$diff'/></a></th>" +
-          "</tr>"
+      .map {
+        case (screenshot, error) =>
+          val isFailedTest = error.isDefined
+          val testClass = screenshot.testClass
+          val testName = screenshot.testName
+          val originalScreenshot = "./images/recorded/" + screenshot.name + ".png"
+          val newScreenshot = "./images/" + screenshot.name + ".png"
+          val diff = if (error.exists(_.isInstanceOf[DifferentScreenshots])) {
+            screenshot.getDiffScreenshotPath("./images/")
+          } else {
+            ""
+          }
+          val color = if (isFailedTest) "red-text" else "green-text"
+          val width = (screenshot.screenshotDimension.width * 0.2).toInt
+          val id = screenshot.name.replace(".", "")
+          "<tr>" +
+            s"<th id='$id'> <p class='$color'>Test class: $testClass</p>" +
+            s"<p class='$color'>Test name: $testName</p></th>" +
+            s"<th> <a href='$originalScreenshot'><img width='$width' src='$originalScreenshot'/></a></th>" +
+            s"<th> <a href='$newScreenshot'><img width='$width' src='$newScreenshot'/></a></th>" +
+            s"<th> <a href='$diff'><img width='$width' src='$diff'/></a></th>" +
+            "</tr>"
       }
       .mkString("\n")
   }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Hard to find failed tests when you have a large tests suite (200 tests) Closes #24 

### :tophat: What is the goal?

Show failed tests first. Failed tests are of much higher interest.

### How is it being implemented?

Group screenshots by test result - failed come first, passed come afterwards.

### How can it be tested?

Didn't find any tests on HTML report markup. Not sure if this PR should introduce such tests. LMKWYT.

### Before
<img width="473" alt="Screen Shot 2019-12-03 at 1 52 14 PM" src="https://user-images.githubusercontent.com/1754632/70081063-c9700300-15d5-11ea-8e0d-f48e7ac16007.png">

### After
<img width="475" alt="Screen Shot 2019-12-03 at 1 55 54 PM" src="https://user-images.githubusercontent.com/1754632/70081085-d5f45b80-15d5-11ea-9a58-43f0b45a4b93.png">


