### PR TITLE
Update Facebook's lib support

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ You can run a single test or test class, just add the `android.testInstrumentati
 If you have included in your project a dependency to related to the dexmaker and you are facing this exception: ``com.android.dx.util.DexException: Multiple dex files define``, you can customize how the facebook SDK is added to your project and exclude the dexmaker library as follows:
 
  ```groovy
-   androidTestCompile ('com.facebook.testing.screenshot:core:0.8.0') {
+   androidTestCompile ('com.facebook.testing.screenshot:core:0.11.0') {
      exclude group: 'com.crittercism.dexmaker', module: 'dexmaker'
      exclude group: 'com.crittercism.dexmaker', module: 'dexmaker-dx'
    }
@@ -217,11 +217,11 @@ If you have included in your project a dependency to related to the dexmaker and
  
 The Shot plugin automatically detects if you are including a compatible version of the screenshot facebook library in your project and, if it's present, it will not include it again.
  
-**Disclaimer**: The only compatible version of the facebook library is 0.8.0 right now, so if you are using any other version we highly encourage to match it with the one Shot is using to avoid problems.
+**Disclaimer**: The only compatible version of the facebook library is 0.9.0 or any higher version right now, so if you are using any other version we highly encourage to match it with the one Shot is using to avoid problems.
 
 ## iOS support
 
-If you want to apply the same testing technique on iOS you can use [Snap.swift](https://github.com/skyweb07/Snap.swift)
+If you want to apply the same testing technique on iOS you can use [Swift Snapshot Testing](https://github.com/pointfreeco/swift-snapshot-testing)
 
 License
 -------

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile 'com.sksamuel.scrimage:scrimage-core_2.12:2.1.8'
     compile 'org.freemarker:freemarker:2.3.23'
     compile 'org.json4s:json4s-native_2.12:3.5.3'
+    compile 'io.github.bitstorm:tinyzip-core:1.0.0'
     testCompile 'org.scalatest:scalatest_2.12:3.0.3'
     testRuntime 'org.pegdown:pegdown:1.4.2'
     testCompile 'org.scalamock:scalamock-scalatest-support_2.12:3.5.0'

--- a/core/src/main/scala/com/karumi/shot/domain/model.scala
+++ b/core/src/main/scala/com/karumi/shot/domain/model.scala
@@ -18,7 +18,7 @@ object Config {
   val androidDependencyMode: FilePath = "androidTestImplementation"
   val androidDependencyGroup: String = "com.facebook.testing.screenshot"
   val androidDependencyName: String = "core"
-  val androidDependencyVersion: String = "0.8.0"
+  val androidDependencyVersion: String = "0.11.0"
   val androidDependency: FilePath =
     s"$androidDependencyGroup:$androidDependencyName:$androidDependencyVersion"
   val screenshotsFolderName: FilePath = "/screenshots/"

--- a/core/src/main/scala/com/karumi/shot/xml/ScreenshotsSuiteXmlParser.scala
+++ b/core/src/main/scala/com/karumi/shot/xml/ScreenshotsSuiteXmlParser.scala
@@ -26,17 +26,19 @@ object ScreenshotsSuiteXmlParser {
       projectName: String,
       screenshotsFolder: Folder,
       temporalScreenshotsFolder: Folder): Screenshot = {
-    val name = (xmlNode \ "name" head).text
+    val name = (xmlNode \ "name" head).text.trim
     val recordedScreenshotPath = screenshotsFolder + name + ".png"
     val temporalScreenshotPath = Config.screenshotsTemporalRootPath + projectName + "/" + name + ".png"
-    val testClass = (xmlNode \ "test_class" head).text
-    val testName = (xmlNode \ "test_name" head).text
+    val testClass = (xmlNode \ "test_class" head).text.trim
+    val testName = (xmlNode \ "test_name" head).text.trim
     val tileWidth = (xmlNode \ "tile_width" head).text.toInt
     val tileHeight = (xmlNode \ "tile_height" head).text.toInt
     val tilesDimension = Dimension(tileWidth, tileHeight)
-    val viewHierarchy = (xmlNode \ "view_hierarchy" head).text
-    val absoluteFileNames = (xmlNode \ "absolute_file_name").map(_.text)
-    val relativeFileNames = (xmlNode \ "relative_file_name").map(_.text)
+    val viewHierarchy = (xmlNode \ "view_hierarchy" head).text.trim
+    val absoluteFileNames =
+      (xmlNode \ "absolute_file_name").map(_.text.trim + ".png")
+    val relativeFileNames =
+      (xmlNode \ "relative_file_name").map(_.text.trim + ".png")
     val recordedPartsPaths =
       relativeFileNames.map(temporalScreenshotsFolder + _)
     Screenshot(
@@ -57,10 +59,11 @@ object ScreenshotsSuiteXmlParser {
   def parseScreenshotSize(screenshot: Screenshot,
                           viewHierarchyContent: String): Screenshot = {
     val json = parse(viewHierarchyContent)
-    val JInt(screenshotLeft) = json \ "left"
-    val JInt(screenshotWidth) = json \ "width"
-    val JInt(screenshotTop) = json \ "top"
-    val JInt(screenshotHeight) = json \ "height"
+    val viewHierarchyNode = json \ "viewHierarchy"
+    val JInt(screenshotLeft) = viewHierarchyNode \ "left"
+    val JInt(screenshotWidth) = viewHierarchyNode \ "width"
+    val JInt(screenshotTop) = viewHierarchyNode \ "top"
+    val JInt(screenshotHeight) = viewHierarchyNode \ "height"
     screenshot.copy(
       screenshotDimension =
         Dimension(screenshotLeft.toInt + screenshotWidth.toInt,

--- a/core/src/test/resources/screenshots-metadata/metadata.xml
+++ b/core/src/test/resources/screenshots-metadata/metadata.xml
@@ -1,213 +1,410 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8' ?>
 <screenshots>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes</name>
-        <test_class>com.karumi.screenshot.MainActivityTest</test_class>
+        <name>com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes</name>
+        <test_class>com.karumi.ui.view.MainActivityTest</test_class>
         <test_name>showsSuperHeroesIfThereAreSomeSuperHeroes</test_name>
         <tile_width>2</tile_width>
         <tile_height>3</tile_height>
-        <view_hierarchy>com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_dump.json</view_hierarchy>
+        <view_hierarchy>com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_dump.json
+        </view_hierarchy>
+        <ax_issues>com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_issues.json</ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2
+        </relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam</name>
-        <test_class>com.karumi.screenshot.MainActivityTest</test_class>
+        <name>com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam</name>
+        <test_class>com.karumi.ui.view.MainActivityTest</test_class>
         <test_name>doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam</test_name>
         <tile_width>2</tile_width>
         <tile_height>3</tile_height>
-        <view_hierarchy>com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_dump.json</view_hierarchy>
+        <view_hierarchy>
+            com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_dump.json
+        </view_hierarchy>
+        <ax_issues>
+            com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_issues.json
+        </ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_0_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_0_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_0_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_0_2.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_0.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_2.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_0_1
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_0_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_0_2
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_0_2
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_0
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_0
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_1
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_2
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_doesNotShowAvengersBadgeIfASuperHeroIsNotPartOfTheAvengersTeam_1_2
+        </relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam</name>
-        <test_class>com.karumi.screenshot.MainActivityTest</test_class>
+        <name>com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam</name>
+        <test_class>com.karumi.ui.view.MainActivityTest</test_class>
         <test_name>showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam</test_name>
         <tile_width>2</tile_width>
         <tile_height>3</tile_height>
-        <view_hierarchy>com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_dump.json</view_hierarchy>
+        <view_hierarchy>
+            com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_dump.json
+        </view_hierarchy>
+        <ax_issues>
+            com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_issues.json
+        </ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_0_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_0_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_0_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_0_2.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_0.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_2.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_0_1
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_0_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_0_2
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_0_2
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_0
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_0
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_1
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_2
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.MainActivityTest_showsAvengersBadgeIfASuperHeroIsPartOfTheAvengersTeam_1_2
+        </relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes</name>
-        <test_class>com.karumi.screenshot.MainActivityTest</test_class>
+        <name>com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes</name>
+        <test_class>com.karumi.ui.view.MainActivityTest</test_class>
         <test_name>showsEmptyCaseIfThereAreNoSuperHeroes</test_name>
         <tile_width>2</tile_width>
         <tile_height>3</tile_height>
-        <view_hierarchy>com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_dump.json</view_hierarchy>
+        <view_hierarchy>com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_dump.json
+        </view_hierarchy>
+        <ax_issues>com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_issues.json</ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_0_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_0_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_0_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_0_2.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_0.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_2.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_0_1
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_0_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_0_2
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_0_2
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_0
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_0
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_1
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_2
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsEmptyCaseIfThereAreNoSuperHeroes_1_2
+        </relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero</name>
-        <test_class>com.karumi.screenshot.MainActivityTest</test_class>
+        <name>com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero</name>
+        <test_class>com.karumi.ui.view.MainActivityTest</test_class>
         <test_name>showsJustOneSuperHero</test_name>
         <tile_width>2</tile_width>
         <tile_height>3</tile_height>
-        <view_hierarchy>com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_dump.json</view_hierarchy>
+        <view_hierarchy>com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_dump.json</view_hierarchy>
+        <ax_issues>com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_issues.json</ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_0_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_0_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_0_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_0_2.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_1_0.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_1_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_1_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_1_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.MainActivityTest_showsJustOneSuperHero_1_2.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_0_1
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_0_1</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_0_2
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_0_2</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_1_0
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_1_0</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_1_1
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_1_1</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_1_2
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.MainActivityTest_showsJustOneSuperHero_1_2</relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam</name>
-        <test_class>com.karumi.screenshot.SuperHeroDetailActivityTest</test_class>
-        <test_name>showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam</test_name>
+        <name>com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam</name>
+        <test_class>com.karumi.ui.view.SuperHeroDetailActivityTest</test_class>
+        <test_name>showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam</test_name>
         <tile_width>2</tile_width>
         <tile_height>3</tile_height>
-        <view_hierarchy>com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_dump.json</view_hierarchy>
+        <view_hierarchy>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_dump.json
+        </view_hierarchy>
+        <ax_issues>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_issues.json
+        </ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_2.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_0.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_2.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_0_1
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_0_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_0_2
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_0_2
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_1_0
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_1_0
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_1_1
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_1_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_1_2
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_showsAvengersBadgeIfSuperHeroIsPartOfTheAvengersTeam_1_2
+        </relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam</name>
-        <test_class>com.karumi.screenshot.SuperHeroDetailActivityTest</test_class>
+        <name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam
+        </name>
+        <test_class>com.karumi.ui.view.SuperHeroDetailActivityTest</test_class>
         <test_name>doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam</test_name>
         <tile_width>2</tile_width>
         <tile_height>3</tile_height>
-        <view_hierarchy>com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_dump.json</view_hierarchy>
+        <view_hierarchy>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_dump.json
+        </view_hierarchy>
+        <ax_issues>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_issues.json
+        </ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_2.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_0.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_1.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_1.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_2.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_2.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_1
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_2
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_0_2
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_0
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_0
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_1
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_1
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_2
+        </absolute_file_name>
+        <relative_file_name>
+            com.karumi.ui.view.SuperHeroDetailActivityTest_doesNotShowAvengersBadgeIfSuperHeroIsNotPartOfTheAvengersTeam_1_2
+        </relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames</name>
-        <test_class>com.karumi.screenshot.SuperHeroViewHolderTest</test_class>
+        <name>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames</name>
+        <test_class>com.karumi.ui.view.SuperHeroViewHolderTest</test_class>
         <test_name>showsSuperHeroesWithLongNames</test_name>
         <tile_width>2</tile_width>
         <tile_height>1</tile_height>
-        <view_hierarchy>com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames_dump.json</view_hierarchy>
+        <view_hierarchy>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames_dump.json
+        </view_hierarchy>
+        <ax_issues>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames_issues.json</ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames_1_0.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames_1_0
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongNames_1_0
+        </relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.SuperHeroViewHolderTest_showsAnySuperHero</name>
-        <test_class>com.karumi.screenshot.SuperHeroViewHolderTest</test_class>
+        <name>com.karumi.ui.view.SuperHeroViewHolderTest_showsAnySuperHero</name>
+        <test_class>com.karumi.ui.view.SuperHeroViewHolderTest</test_class>
         <test_name>showsAnySuperHero</test_name>
         <tile_width>2</tile_width>
         <tile_height>1</tile_height>
-        <view_hierarchy>com.karumi.screenshot.SuperHeroViewHolderTest_showsAnySuperHero_dump.json</view_hierarchy>
+        <view_hierarchy>com.karumi.ui.view.SuperHeroViewHolderTest_showsAnySuperHero_dump.json</view_hierarchy>
+        <ax_issues>com.karumi.ui.view.SuperHeroViewHolderTest_showsAnySuperHero_issues.json</ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroViewHolderTest_showsAnySuperHero.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroViewHolderTest_showsAnySuperHero.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroViewHolderTest_showsAnySuperHero_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroViewHolderTest_showsAnySuperHero_1_0.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroViewHolderTest_showsAnySuperHero
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.SuperHeroViewHolderTest_showsAnySuperHero</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroViewHolderTest_showsAnySuperHero_1_0
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.SuperHeroViewHolderTest_showsAnySuperHero_1_0</relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.SuperHeroViewHolderTest_showsAvengersBadge</name>
-        <test_class>com.karumi.screenshot.SuperHeroViewHolderTest</test_class>
+        <name>com.karumi.ui.view.SuperHeroViewHolderTest_showsAvengersBadge</name>
+        <test_class>com.karumi.ui.view.SuperHeroViewHolderTest</test_class>
         <test_name>showsAvengersBadge</test_name>
         <tile_width>2</tile_width>
         <tile_height>1</tile_height>
-        <view_hierarchy>com.karumi.screenshot.SuperHeroViewHolderTest_showsAvengersBadge_dump.json</view_hierarchy>
+        <view_hierarchy>com.karumi.ui.view.SuperHeroViewHolderTest_showsAvengersBadge_dump.json</view_hierarchy>
+        <ax_issues>com.karumi.ui.view.SuperHeroViewHolderTest_showsAvengersBadge_issues.json</ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroViewHolderTest_showsAvengersBadge.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroViewHolderTest_showsAvengersBadge.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroViewHolderTest_showsAvengersBadge_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroViewHolderTest_showsAvengersBadge_1_0.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroViewHolderTest_showsAvengersBadge
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.SuperHeroViewHolderTest_showsAvengersBadge</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroViewHolderTest_showsAvengersBadge_1_0
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.SuperHeroViewHolderTest_showsAvengersBadge_1_0</relative_file_name>
     </screenshot>
     <screenshot>
         <description/>
-        <name>com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions</name>
-        <test_class>com.karumi.screenshot.SuperHeroViewHolderTest</test_class>
+        <name>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions</name>
+        <test_class>com.karumi.ui.view.SuperHeroViewHolderTest</test_class>
         <test_name>showsSuperHeroesWithLongDescriptions</test_name>
         <tile_width>2</tile_width>
         <tile_height>1</tile_height>
-        <view_hierarchy>com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions_dump.json</view_hierarchy>
+        <view_hierarchy>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions_dump.json
+        </view_hierarchy>
+        <ax_issues>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions_issues.json
+        </ax_issues>
         <extras/>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions.png</relative_file_name>
-        <absolute_file_name>/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions_1_0.png</absolute_file_name>
-        <relative_file_name>com.karumi.screenshot.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions_1_0.png</relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions
+        </relative_file_name>
+        <absolute_file_name>
+            /sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions_1_0
+        </absolute_file_name>
+        <relative_file_name>com.karumi.ui.view.SuperHeroViewHolderTest_showsSuperHeroesWithLongDescriptions_1_0
+        </relative_file_name>
     </screenshot>
 </screenshots>

--- a/core/src/test/resources/screenshots-metadata/view-hierarchy.json
+++ b/core/src/test/resources/screenshots-metadata/view-hierarchy.json
@@ -1,233 +1,270 @@
 {
-  "class": "com.android.internal.policy.impl.PhoneWindow.DecorView",
-  "left": 0,
-  "top": 0,
-  "width": 720,
-  "height": 1280,
-  "children": [
-    {
-      "class": "android.widget.LinearLayout",
+  "viewHierarchy": {
+    "class": "android.widget.RelativeLayout",
+    "left": 0,
+    "top": 0,
+    "width": 768,
+    "height": 400,
+    "children": [
+      {
+        "class": "android.widget.ImageView",
+        "left": 0,
+        "top": 0,
+        "width": 768,
+        "height": 400
+      },
+      {
+        "class": "android.view.View",
+        "left": 0,
+        "top": 200,
+        "width": 768,
+        "height": 200
+      },
+      {
+        "class": "android.widget.TextView",
+        "left": 32,
+        "top": 32,
+        "width": 704,
+        "height": 336
+      },
+      {
+        "class": "android.widget.ImageView",
+        "left": 0,
+        "top": 0,
+        "width": 0,
+        "height": 0
+      }
+    ]
+  },
+  "axHierarchy": {
+    "class": "android.widget.RelativeLayout",
+    "actionList": null,
+    "boundsInParent": {
       "left": 0,
+      "right": 0,
       "top": 0,
-      "width": 768,
-      "height": 1280,
-      "children": [
-        {
-          "class": "android.view.ViewStub",
-          "left": 0,
-          "top": 0,
-          "width": 0,
-          "height": 0
-        },
-        {
-          "class": "android.widget.FrameLayout",
-          "left": 0,
-          "top": 50,
-          "width": 768,
-          "height": 1230,
-          "children": [
-            {
-              "class": "android.support.v7.widget.FitWindowsLinearLayout",
-              "left": 0,
-              "top": 50,
-              "width": 768,
-              "height": 1230,
-              "children": [
-                {
-                  "class": "android.support.v7.widget.ViewStubCompat",
-                  "left": 0,
-                  "top": 50,
-                  "width": 0,
-                  "height": 0
-                },
-                {
-                  "class": "android.support.v7.widget.ContentFrameLayout",
-                  "left": 0,
-                  "top": 50,
-                  "width": 768,
-                  "height": 1230,
-                  "children": [
-                    {
-                      "class": "android.widget.RelativeLayout",
-                      "left": 0,
-                      "top": 50,
-                      "width": 768,
-                      "height": 1230,
-                      "children": [
-                        {
-                          "class": "android.support.v7.widget.Toolbar",
-                          "left": 0,
-                          "top": 50,
-                          "width": 768,
-                          "height": 112,
-                          "children": [
-                            {
-                              "class": "android.widget.TextView",
-                              "left": 32,
-                              "top": 79,
-                              "width": 294,
-                              "height": 54
-                            },
-                            {
-                              "class": "android.support.v7.widget.ActionMenuView",
-                              "left": 768,
-                              "top": 50,
-                              "width": 0,
-                              "height": 112,
-                              "children": []
-                            }
-                          ]
-                        },
-                        {
-                          "class": "android.support.v7.widget.RecyclerView",
-                          "left": 0,
-                          "top": 162,
-                          "width": 768,
-                          "height": 1118,
-                          "children": [
-                            {
-                              "class": "android.widget.RelativeLayout",
-                              "left": 0,
-                              "top": 162,
-                              "width": 768,
-                              "height": 400,
-                              "children": [
-                                {
-                                  "class": "android.support.v7.widget.AppCompatImageView",
-                                  "left": 0,
-                                  "top": 162,
-                                  "width": 768,
-                                  "height": 400
-                                },
-                                {
-                                  "class": "android.view.View",
-                                  "left": 0,
-                                  "top": 362,
-                                  "width": 768,
-                                  "height": 200
-                                },
-                                {
-                                  "class": "android.support.v7.widget.AppCompatTextView",
-                                  "left": 32,
-                                  "top": 492,
-                                  "width": 170,
-                                  "height": 38
-                                },
-                                {
-                                  "class": "android.support.v7.widget.AppCompatImageView",
-                                  "left": 0,
-                                  "top": 162,
-                                  "width": 0,
-                                  "height": 0
-                                }
-                              ]
-                            },
-                            {
-                              "class": "android.widget.RelativeLayout",
-                              "left": 0,
-                              "top": 562,
-                              "width": 768,
-                              "height": 400,
-                              "children": [
-                                {
-                                  "class": "android.support.v7.widget.AppCompatImageView",
-                                  "left": 0,
-                                  "top": 562,
-                                  "width": 768,
-                                  "height": 400
-                                },
-                                {
-                                  "class": "android.view.View",
-                                  "left": 0,
-                                  "top": 762,
-                                  "width": 768,
-                                  "height": 200
-                                },
-                                {
-                                  "class": "android.support.v7.widget.AppCompatTextView",
-                                  "left": 32,
-                                  "top": 892,
-                                  "width": 170,
-                                  "height": 38
-                                },
-                                {
-                                  "class": "android.support.v7.widget.AppCompatImageView",
-                                  "left": 0,
-                                  "top": 562,
-                                  "width": 0,
-                                  "height": 0
-                                }
-                              ]
-                            },
-                            {
-                              "class": "android.widget.RelativeLayout",
-                              "left": 0,
-                              "top": 962,
-                              "width": 768,
-                              "height": 400,
-                              "children": [
-                                {
-                                  "class": "android.support.v7.widget.AppCompatImageView",
-                                  "left": 0,
-                                  "top": 962,
-                                  "width": 768,
-                                  "height": 400
-                                },
-                                {
-                                  "class": "android.view.View",
-                                  "left": 0,
-                                  "top": 1162,
-                                  "width": 768,
-                                  "height": 200
-                                },
-                                {
-                                  "class": "android.support.v7.widget.AppCompatTextView",
-                                  "left": 32,
-                                  "top": 1292,
-                                  "width": 170,
-                                  "height": 38
-                                },
-                                {
-                                  "class": "android.support.v7.widget.AppCompatImageView",
-                                  "left": 0,
-                                  "top": 962,
-                                  "width": 0,
-                                  "height": 0
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "class": "android.support.v4.widget.ContentLoadingProgressBar",
-                          "left": 0,
-                          "top": 50,
-                          "width": 0,
-                          "height": 0
-                        },
-                        {
-                          "class": "android.support.v7.widget.AppCompatTextView",
-                          "left": 0,
-                          "top": 50,
-                          "width": 0,
-                          "height": 0
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
+      "bottom": 0
     },
-    {
-      "class": "android.view.View",
+    "boundsInScreen": {
       "left": 0,
+      "right": 0,
       "top": 0,
-      "width": 768,
-      "height": 50
-    }
-  ]
+      "bottom": 0
+    },
+    "canOpenPopup": false,
+    "childCount": 0,
+    "collectionInfo": null,
+    "collectionItemInfo": null,
+    "contentDescription": null,
+    "error": null,
+    "extras": "Bundle[{}]",
+    "inputType": 0,
+    "isCheckable": false,
+    "isChecked": false,
+    "isClickable": false,
+    "isContentInvalid": false,
+    "isDismissable": false,
+    "isEditable": false,
+    "isEnabled": false,
+    "isFocusable": false,
+    "isImportantForAccessibility": false,
+    "isLongClickable": false,
+    "isMultiLine": false,
+    "isPassword": false,
+    "isScrollable": false,
+    "isSelected": false,
+    "isVisibleToUser": false,
+    "liveRegion": 0,
+    "maxTextLength": -1,
+    "movementGranularities": 0,
+    "rangeInfo": null,
+    "text": null,
+    "children": [
+      {
+        "class": "android.widget.ImageView",
+        "actionList": null,
+        "boundsInParent": {
+          "left": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0
+        },
+        "boundsInScreen": {
+          "left": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0
+        },
+        "canOpenPopup": false,
+        "childCount": 0,
+        "collectionInfo": null,
+        "collectionItemInfo": null,
+        "contentDescription": null,
+        "error": null,
+        "extras": "Bundle[{}]",
+        "inputType": 0,
+        "isCheckable": false,
+        "isChecked": false,
+        "isClickable": false,
+        "isContentInvalid": false,
+        "isDismissable": false,
+        "isEditable": false,
+        "isEnabled": false,
+        "isFocusable": false,
+        "isImportantForAccessibility": false,
+        "isLongClickable": false,
+        "isMultiLine": false,
+        "isPassword": false,
+        "isScrollable": false,
+        "isSelected": false,
+        "isVisibleToUser": false,
+        "liveRegion": 0,
+        "maxTextLength": -1,
+        "movementGranularities": 0,
+        "rangeInfo": null,
+        "text": null,
+        "children": null
+      },
+      {
+        "class": "android.view.View",
+        "actionList": null,
+        "boundsInParent": {
+          "left": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0
+        },
+        "boundsInScreen": {
+          "left": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0
+        },
+        "canOpenPopup": false,
+        "childCount": 0,
+        "collectionInfo": null,
+        "collectionItemInfo": null,
+        "contentDescription": null,
+        "error": null,
+        "extras": "Bundle[{}]",
+        "inputType": 0,
+        "isCheckable": false,
+        "isChecked": false,
+        "isClickable": false,
+        "isContentInvalid": false,
+        "isDismissable": false,
+        "isEditable": false,
+        "isEnabled": false,
+        "isFocusable": false,
+        "isImportantForAccessibility": false,
+        "isLongClickable": false,
+        "isMultiLine": false,
+        "isPassword": false,
+        "isScrollable": false,
+        "isSelected": false,
+        "isVisibleToUser": false,
+        "liveRegion": 0,
+        "maxTextLength": -1,
+        "movementGranularities": 0,
+        "rangeInfo": null,
+        "text": null,
+        "children": null
+      },
+      {
+        "class": "android.widget.TextView",
+        "actionList": [
+          256,
+          512,
+          131072
+        ],
+        "boundsInParent": {
+          "left": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0
+        },
+        "boundsInScreen": {
+          "left": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0
+        },
+        "canOpenPopup": false,
+        "childCount": 0,
+        "collectionInfo": null,
+        "collectionItemInfo": null,
+        "contentDescription": null,
+        "error": null,
+        "extras": "Bundle[{}]",
+        "inputType": 0,
+        "isCheckable": false,
+        "isChecked": false,
+        "isClickable": false,
+        "isContentInvalid": false,
+        "isDismissable": false,
+        "isEditable": false,
+        "isEnabled": false,
+        "isFocusable": false,
+        "isImportantForAccessibility": false,
+        "isLongClickable": false,
+        "isMultiLine": true,
+        "isPassword": false,
+        "isScrollable": false,
+        "isSelected": false,
+        "isVisibleToUser": false,
+        "liveRegion": 0,
+        "maxTextLength": -1,
+        "movementGranularities": 31,
+        "rangeInfo": null,
+        "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor\nincididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation\nullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in\nvoluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non\nproident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n",
+        "children": null
+      },
+      {
+        "class": "android.widget.ImageView",
+        "actionList": null,
+        "boundsInParent": {
+          "left": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0
+        },
+        "boundsInScreen": {
+          "left": 0,
+          "right": 0,
+          "top": 0,
+          "bottom": 0
+        },
+        "canOpenPopup": false,
+        "childCount": 0,
+        "collectionInfo": null,
+        "collectionItemInfo": null,
+        "contentDescription": null,
+        "error": null,
+        "extras": "Bundle[{}]",
+        "inputType": 0,
+        "isCheckable": false,
+        "isChecked": false,
+        "isClickable": false,
+        "isContentInvalid": false,
+        "isDismissable": false,
+        "isEditable": false,
+        "isEnabled": false,
+        "isFocusable": false,
+        "isImportantForAccessibility": false,
+        "isLongClickable": false,
+        "isMultiLine": false,
+        "isPassword": false,
+        "isScrollable": false,
+        "isSelected": false,
+        "isVisibleToUser": false,
+        "liveRegion": 0,
+        "maxTextLength": -1,
+        "movementGranularities": 0,
+        "rangeInfo": null,
+        "text": null,
+        "children": null
+      }
+    ]
+  },
+  "version": 1
 }

--- a/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class ConfigSpec extends FlatSpec with Matchers {
 
   "Config" should "use the screenshot tests library implemented by Facebook" in {
-    Config.androidDependency shouldBe "com.facebook.testing.screenshot:core:0.8.0"
+    Config.androidDependency shouldBe "com.facebook.testing.screenshot:core:0.11.0"
   }
 
   it should "add the dependency using the androidTestImplementation mode" in {

--- a/core/src/test/scala/com/karumi/shot/xml/ScreenshotsSuiteXmlParserSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/xml/ScreenshotsSuiteXmlParserSpec.scala
@@ -44,40 +44,40 @@ class ScreenshotsSuiteXmlParserSpec
 
     screenshots.size shouldBe 11
     val firstScreenshot = screenshots.head
-    firstScreenshot.name shouldBe "com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes"
-    firstScreenshot.recordedScreenshotPath shouldBe "/screenshots/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png"
-    firstScreenshot.temporalScreenshotPath shouldBe "/tmp/shot/screenshot/flowup/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png"
-    firstScreenshot.testClass shouldBe "com.karumi.screenshot.MainActivityTest"
+    firstScreenshot.name shouldBe "com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes"
+    firstScreenshot.recordedScreenshotPath shouldBe "/screenshots/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png"
+    firstScreenshot.temporalScreenshotPath shouldBe "/tmp/shot/screenshot/flowup/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png"
+    firstScreenshot.testClass shouldBe "com.karumi.ui.view.MainActivityTest"
     firstScreenshot.testName shouldBe "showsSuperHeroesIfThereAreSomeSuperHeroes"
     firstScreenshot.tilesDimension.width shouldBe 2
     firstScreenshot.tilesDimension.height shouldBe 3
-    firstScreenshot.viewHierarchy shouldBe "com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_dump.json"
+    firstScreenshot.viewHierarchy shouldBe "com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_dump.json"
     firstScreenshot.absoluteFileNames shouldBe Seq(
-      "/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png",
-      "/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1.png",
-      "/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2.png",
-      "/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0.png",
-      "/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1.png",
-      "/mnt/sdcard/screenshots/com.karumi.screenshot.test/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2.png"
+      "/sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png",
+      "/sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1.png",
+      "/sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2.png",
+      "/sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0.png",
+      "/sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1.png",
+      "/sdcard/screenshots/com.karumi.test/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2.png"
     )
     firstScreenshot.relativeFileNames shouldBe Seq(
-      "com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png",
-      "com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1.png",
-      "com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2.png",
-      "com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0.png",
-      "com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1.png",
-      "com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2.png"
+      "com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png",
+      "com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1.png",
+      "com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2.png",
+      "com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0.png",
+      "com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1.png",
+      "com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2.png"
     )
     firstScreenshot.recordedPartsPaths shouldBe Seq(
-      "/screenshots/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png",
-      "/screenshots/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1.png",
-      "/screenshots/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2.png",
-      "/screenshots/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0.png",
-      "/screenshots/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1.png",
-      "/screenshots/screenshots-default/com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2.png"
+      "/screenshots/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png",
+      "/screenshots/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_1.png",
+      "/screenshots/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_0_2.png",
+      "/screenshots/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_0.png",
+      "/screenshots/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_1.png",
+      "/screenshots/screenshots-default/com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes_1_2.png"
     )
-    firstScreenshot.screenshotDimension.width shouldBe 720
-    firstScreenshot.screenshotDimension.height shouldBe 1280
-    firstScreenshot.fileName shouldBe "com.karumi.screenshot.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png"
+    firstScreenshot.screenshotDimension.width shouldBe 768
+    firstScreenshot.screenshotDimension.height shouldBe 400
+    firstScreenshot.fileName shouldBe "com.karumi.ui.view.MainActivityTest_showsSuperHeroesIfThereAreSomeSuperHeroes.png"
   }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #82 

### :tophat: What is the goal?

Update the Gradle plugin core components to be able to parse the new metadata format and the new files format used by recently published Facebook's library versions.

### How is it being implemented?

To implement this feature we've followed these steps:

* Change the configuration to use the latest release as the default dependency added when the plugin starts.
* Change how we parse the file xml metadata to match the new requirements.
* Update the coverage to use the new xml metadata.
* Change how we parse the view hierarchy json metadata.
* Update the coverage to use the new json metadata file.
* Change the code to unzip the pulled files from the device. We used a simple java library to do this.
* Update the project documentation reflecting the new change and also recommending a different snapshot testing library for iOS.

### How can it be tested?

🤖 