### PR TITLE
Add process logger to the usage of ADB

### DIFF
--- a/core/src/main/scala/com/karumi/shot/android/Adb.scala
+++ b/core/src/main/scala/com/karumi/shot/android/Adb.scala
@@ -13,7 +13,8 @@ class Adb {
   private final val CR_ASCII_DECIMAL = 13
   private val logger = ProcessLogger(
     outputMessage => println("Shot ADB output: " + outputMessage),
-    errorMessage => println(Console.RED + "Shot ADB error: " + errorMessage + Console.RESET)
+    errorMessage =>
+      println(Console.RED + "Shot ADB error: " + errorMessage + Console.RESET)
   )
 
   def devices: List[String] = {

--- a/core/src/main/scala/com/karumi/shot/android/Adb.scala
+++ b/core/src/main/scala/com/karumi/shot/android/Adb.scala
@@ -11,6 +11,10 @@ object Adb {
 class Adb {
 
   private final val CR_ASCII_DECIMAL = 13
+  private val logger = ProcessLogger(
+    o => println("Shot ADB output: " + o),
+    e => println(Console.RED + "Shot ADB error: " + e + Console.RESET)
+  )
 
   def devices: List[String] = {
     executeAdbCommandWithResult("devices")
@@ -34,10 +38,10 @@ class Adb {
       s"-s $device shell rm -r /sdcard/screenshots/$appId/screenshots-default/")
 
   private def executeAdbCommand(command: String): Int =
-    s"${Adb.adbBinaryPath} $command".!
+    s"${Adb.adbBinaryPath} $command" ! logger
 
   private def executeAdbCommandWithResult(command: String): String =
-    s"${Adb.adbBinaryPath} $command".!!
+    s"${Adb.adbBinaryPath} $command" !! logger
 
   private def isCarriageReturnASCII(device: String): Boolean =
     device.charAt(0) == CR_ASCII_DECIMAL

--- a/core/src/main/scala/com/karumi/shot/android/Adb.scala
+++ b/core/src/main/scala/com/karumi/shot/android/Adb.scala
@@ -12,8 +12,8 @@ class Adb {
 
   private final val CR_ASCII_DECIMAL = 13
   private val logger = ProcessLogger(
-    o => println("Shot ADB output: " + o),
-    e => println(Console.RED + "Shot ADB error: " + e + Console.RESET)
+    outputMessage => println("Shot ADB output: " + outputMessage),
+    errorMessage => println(Console.RED + "Shot ADB error: " + errorMessage + Console.RESET)
   )
 
   def devices: List[String] = {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #87 

### :tophat: What is the goal?

Improve the log traces shown to the user when using adb.

### How is it being implemented?

We've configured a simple ``ProcessLogger``  instance when executing adb commands.

### How can it be tested?

There is no need to add automated tests for these log traces.