### PR TITLE
Move hide ignored views to the target app thread

### DIFF
--- a/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
+++ b/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
@@ -113,7 +113,6 @@ interface ScreenshotTest {
         }
     }
 
-
     fun waitForAnimationsToFinish() {
         getInstrumentation().waitForIdleSync()
         Espresso.onIdle()

--- a/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
+++ b/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
@@ -107,10 +107,12 @@ interface ScreenshotTest {
         waitForAnimationsToFinish()
     }
 
-    private fun hideIgnoredViews(view: View) =
+    private fun hideIgnoredViews(view: View) = runOnUi {
         view.filterChildrenViews { children -> children.id in ignoredViews }.forEach { viewToIgnore ->
             viewToIgnore.visibility = INVISIBLE
         }
+    }
+
 
     fun waitForAnimationsToFinish() {
         getInstrumentation().waitForIdleSync()


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Fixes #114

### :tophat: What is the goal?

Fix a crash found when ignoring webview activities.

### How is it being implemented?

We've moved the ignoredViews hide process to the target app main thread.

### How can it be tested?

🤖 