### PR TITLE
Include help message

### DIFF
--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -102,6 +102,11 @@ class Shot(adb: Adb,
     if (updatedComparision.hasErrors) {
       consoleReporter.showErrors(updatedComparision,
                                  newScreenshotsVerificationReportFolder)
+
+      console.showError(
+        "🤔 Do you a need a hand with your automated tests or your Android app?")
+      console.showError(
+        "   We'll be happy to help! Send us an email to hello@karumi.com\n")
     } else {
       console.showSuccess("✅  Yeah!!! Your tests are passing.")
     }


### PR DESCRIPTION
### :tophat: What is the goal?

Add a message to the builds failing to show where they can find us in order to find some help with their app :smiley:

### How is it being implemented?

To implement this feature I've just changed the verification error message a little bit.
