### PR TITLE
Allow running emulator scripts on MacOS Catalina

### DIFF
--- a/shot-consumer-flavors/scripts/create_emulator.sh
+++ b/shot-consumer-flavors/scripts/create_emulator.sh
@@ -7,7 +7,7 @@ fi
 
 echo "Creating a brand new SDCard..."
 rm -rf sdcard_2.img
-$ANDROID_HOME/tools/mksdcard -l e 1G sdcard_2.img
+$ANDROID_HOME/emulator/mksdcard -l e 1G sdcard_2.img
 echo "SDCard created!"
 
 echo "Downloading the image to create the emulator..."

--- a/shot-consumer/scripts/create_emulator.sh
+++ b/shot-consumer/scripts/create_emulator.sh
@@ -7,7 +7,7 @@ fi
 
 echo "Creating a brand new SDCard..."
 rm -rf sdcard.img
-$ANDROID_HOME/tools/mksdcard -l e 1G sdcard.img
+$ANDROID_HOME/emulator/mksdcard -l e 1G sdcard.img
 echo "SDCard created!"
 
 echo "Downloading the image to create the emulator..."


### PR DESCRIPTION
### :pushpin: References
I mentioned this here: https://github.com/Karumi/Shot/issues/112#issuecomment-629179551

### :tophat: What is the goal?

Allow running Shot sample scripts on MacOS Catalina. Running `$ANDROID_HOME/tools/mksdcard` fails with `bad CPU type in executable`.

### How is it being implemented?

By using the 64-bit mksdcard executable which is now part of the emulator tools package. The SDK Tools is compiled for 32-bit and - if I understand correctly - is no longer supported.
See: https://developer.android.com/studio/command-line#tools-emulator

### How can it be tested?

By running one of `create_emulator.sh` scripts in Shot repo on MacOS Catalina.
Unfortunately I don't have a way to test this on Windows/Linux, so let's see if it passes on CI. :)