### PR TITLE
Create tasks lazily

### DIFF
--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -69,7 +69,7 @@ class ShotPlugin extends Plugin[Project] {
       getAndroidLibraryExtension(project)
     val baseTask =
       project.getTasks.register(Config.defaultTaskName,
-        classOf[ExecuteScreenshotTestsForEveryFlavor])
+                                classOf[ExecuteScreenshotTestsForEveryFlavor])
     libraryExtension.getLibraryVariants.all { variant =>
       addTaskToVariant(project, baseTask, variant)
     }
@@ -80,7 +80,7 @@ class ShotPlugin extends Plugin[Project] {
       getAndroidAppExtension(project)
     val baseTask =
       project.getTasks.register(Config.defaultTaskName,
-        classOf[ExecuteScreenshotTestsForEveryFlavor])
+                                classOf[ExecuteScreenshotTestsForEveryFlavor])
     appExtension.getApplicationVariants.all { variant =>
       addTaskToVariant(project, baseTask, variant)
     }
@@ -134,7 +134,7 @@ class ShotPlugin extends Plugin[Project] {
     val tasks = project.getTasks
     val removeScreenshots = tasks
       .register(RemoveScreenshotsTask.name(flavor, buildType),
-        classOf[RemoveScreenshotsTask])
+                classOf[RemoveScreenshotsTask])
 
     removeScreenshots.configure { task =>
       task.setDescription(
@@ -146,7 +146,7 @@ class ShotPlugin extends Plugin[Project] {
 
     val downloadScreenshots = tasks
       .register(DownloadScreenshotsTask.name(flavor, buildType),
-        classOf[DownloadScreenshotsTask])
+                classOf[DownloadScreenshotsTask])
     downloadScreenshots.configure { task =>
       task.setDescription(
         DownloadScreenshotsTask.description(flavor, buildType))
@@ -156,7 +156,7 @@ class ShotPlugin extends Plugin[Project] {
     }
     val executeScreenshot = tasks
       .register(ExecuteScreenshotTests.name(flavor, buildType),
-        classOf[ExecuteScreenshotTests])
+                classOf[ExecuteScreenshotTests])
     executeScreenshot.configure { task =>
       task.setDescription(
         ExecuteScreenshotTests.description(flavor, buildType))

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -23,6 +23,7 @@ import com.karumi.shot.tasks.{
 import com.karumi.shot.ui.Console
 import org.gradle.api.{Plugin, Project, Task}
 import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.tasks.TaskProvider
 
 class ShotPlugin extends Plugin[Project] {
 
@@ -67,8 +68,8 @@ class ShotPlugin extends Plugin[Project] {
     val libraryExtension =
       getAndroidLibraryExtension(project)
     val baseTask =
-      project.getTasks.create(Config.defaultTaskName,
-                              classOf[ExecuteScreenshotTestsForEveryFlavor])
+      project.getTasks.register(Config.defaultTaskName,
+        classOf[ExecuteScreenshotTestsForEveryFlavor])
     libraryExtension.getLibraryVariants.all { variant =>
       addTaskToVariant(project, baseTask, variant)
     }
@@ -78,15 +79,15 @@ class ShotPlugin extends Plugin[Project] {
     val appExtension =
       getAndroidAppExtension(project)
     val baseTask =
-      project.getTasks.create(Config.defaultTaskName,
-                              classOf[ExecuteScreenshotTestsForEveryFlavor])
+      project.getTasks.register(Config.defaultTaskName,
+        classOf[ExecuteScreenshotTestsForEveryFlavor])
     appExtension.getApplicationVariants.all { variant =>
       addTaskToVariant(project, baseTask, variant)
     }
   }
 
   private def addTaskToVariant(project: Project,
-                               baseTask: ExecuteScreenshotTestsForEveryFlavor,
+                               baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor],
                                variant: BaseVariant) = {
     val flavor = variant.getMergedFlavor
     checkIfApplicationIdIsConfigured(project, flavor)
@@ -122,7 +123,7 @@ class ShotPlugin extends Plugin[Project] {
                           flavor: String,
                           buildType: BuildType,
                           appId: String,
-                          baseTask: Task): Unit = {
+                          baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor]): Unit = {
     val extension =
       project.getExtensions.getByType[ShotExtension](classOf[ShotExtension])
     val instrumentationTask = if (extension.useComposer) {
@@ -132,38 +133,51 @@ class ShotPlugin extends Plugin[Project] {
     }
     val tasks = project.getTasks
     val removeScreenshots = tasks
-      .create(RemoveScreenshotsTask.name(flavor, buildType),
-              classOf[RemoveScreenshotsTask])
-      .asInstanceOf[ShotTask]
-    removeScreenshots.setDescription(
-      RemoveScreenshotsTask.description(flavor, buildType))
-    removeScreenshots.flavor = flavor
-    removeScreenshots.buildType = buildType
-    removeScreenshots.appId = appId
-    val downloadScreenshots = tasks
-      .create(DownloadScreenshotsTask.name(flavor, buildType),
-              classOf[DownloadScreenshotsTask])
-    downloadScreenshots.setDescription(
-      DownloadScreenshotsTask.description(flavor, buildType))
-    downloadScreenshots.flavor = flavor
-    downloadScreenshots.buildType = buildType
-    downloadScreenshots.appId = appId
-    val executeScreenshot = tasks
-      .create(ExecuteScreenshotTests.name(flavor, buildType),
-              classOf[ExecuteScreenshotTests])
-    executeScreenshot.setDescription(
-      ExecuteScreenshotTests.description(flavor, buildType))
-    executeScreenshot.flavor = flavor
-    executeScreenshot.buildType = buildType
-    executeScreenshot.appId = appId
-    if (extension.runInstrumentation) {
-      executeScreenshot.dependsOn(instrumentationTask)
-      executeScreenshot.dependsOn(downloadScreenshots)
-      executeScreenshot.dependsOn(removeScreenshots)
-      downloadScreenshots.mustRunAfter(instrumentationTask)
-      removeScreenshots.mustRunAfter(downloadScreenshots)
+      .register(RemoveScreenshotsTask.name(flavor, buildType),
+        classOf[RemoveScreenshotsTask])
+
+    removeScreenshots.configure { task =>
+      task.setDescription(
+        RemoveScreenshotsTask.description(flavor, buildType))
+      task.flavor = flavor
+      task.buildType = buildType
+      task.appId = appId
     }
-    baseTask.dependsOn(executeScreenshot)
+
+    val downloadScreenshots = tasks
+      .register(DownloadScreenshotsTask.name(flavor, buildType),
+        classOf[DownloadScreenshotsTask])
+    downloadScreenshots.configure { task =>
+      task.setDescription(
+        DownloadScreenshotsTask.description(flavor, buildType))
+      task.flavor = flavor
+      task.buildType = buildType
+      task.appId = appId
+    }
+    val executeScreenshot = tasks
+      .register(ExecuteScreenshotTests.name(flavor, buildType),
+        classOf[ExecuteScreenshotTests])
+    executeScreenshot.configure { task =>
+      task.setDescription(
+        ExecuteScreenshotTests.description(flavor, buildType))
+      task.flavor = flavor
+      task.buildType = buildType
+      task.appId = appId
+    }
+
+    if (extension.runInstrumentation) {
+      executeScreenshot.configure { task =>
+        task.dependsOn(instrumentationTask)
+        task.dependsOn(downloadScreenshots)
+        task.dependsOn(removeScreenshots)
+      }
+
+      downloadScreenshots.configure { task => task.mustRunAfter(instrumentationTask) }
+      removeScreenshots.configure { task => task.mustRunAfter(downloadScreenshots) }
+    }
+    baseTask.configure { task =>
+      task.dependsOn(executeScreenshot)
+    }
   }
 
   private def addAndroidTestDependency(project: Project): Unit = {

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -1,8 +1,8 @@
 package com.karumi.shot
 
 import com.android.build.gradle.api.BaseVariant
-import com.android.builder.model.{BuildType, ProductFlavor}
 import com.android.build.gradle.{AppExtension, LibraryExtension}
+import com.android.builder.model.{BuildType, ProductFlavor}
 import com.karumi.shot.android.Adb
 import com.karumi.shot.base64.Base64Encoder
 import com.karumi.shot.domain.Config
@@ -17,13 +17,12 @@ import com.karumi.shot.tasks.{
   DownloadScreenshotsTask,
   ExecuteScreenshotTests,
   ExecuteScreenshotTestsForEveryFlavor,
-  RemoveScreenshotsTask,
-  ShotTask
+  RemoveScreenshotsTask
 }
 import com.karumi.shot.ui.Console
-import org.gradle.api.{Plugin, Project, Task}
 import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.{Plugin, Project}
 
 class ShotPlugin extends Plugin[Project] {
 
@@ -68,8 +67,9 @@ class ShotPlugin extends Plugin[Project] {
     val libraryExtension =
       getAndroidLibraryExtension(project)
     val baseTask =
-      project.getTasks.register(Config.defaultTaskName,
-                                classOf[ExecuteScreenshotTestsForEveryFlavor])
+      project.getTasks
+        .register(Config.defaultTaskName,
+                  classOf[ExecuteScreenshotTestsForEveryFlavor])
     libraryExtension.getLibraryVariants.all { variant =>
       addTaskToVariant(project, baseTask, variant)
     }
@@ -79,16 +79,18 @@ class ShotPlugin extends Plugin[Project] {
     val appExtension =
       getAndroidAppExtension(project)
     val baseTask =
-      project.getTasks.register(Config.defaultTaskName,
-                                classOf[ExecuteScreenshotTestsForEveryFlavor])
+      project.getTasks
+        .register(Config.defaultTaskName,
+                  classOf[ExecuteScreenshotTestsForEveryFlavor])
     appExtension.getApplicationVariants.all { variant =>
       addTaskToVariant(project, baseTask, variant)
     }
   }
 
-  private def addTaskToVariant(project: Project,
-                               baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor],
-                               variant: BaseVariant) = {
+  private def addTaskToVariant(
+      project: Project,
+      baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor],
+      variant: BaseVariant) = {
     val flavor = variant.getMergedFlavor
     checkIfApplicationIdIsConfigured(project, flavor)
     val completeAppId = flavor.getApplicationId + Option(
@@ -119,11 +121,12 @@ class ShotPlugin extends Plugin[Project] {
     project.getExtensions.add(name, new ShotExtension())
   }
 
-  private def addTasksFor(project: Project,
-                          flavor: String,
-                          buildType: BuildType,
-                          appId: String,
-                          baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor]): Unit = {
+  private def addTasksFor(
+      project: Project,
+      flavor: String,
+      buildType: BuildType,
+      appId: String,
+      baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor]): Unit = {
     val extension =
       project.getExtensions.getByType[ShotExtension](classOf[ShotExtension])
     val instrumentationTask = if (extension.useComposer) {
@@ -137,8 +140,7 @@ class ShotPlugin extends Plugin[Project] {
                 classOf[RemoveScreenshotsTask])
 
     removeScreenshots.configure { task =>
-      task.setDescription(
-        RemoveScreenshotsTask.description(flavor, buildType))
+      task.setDescription(RemoveScreenshotsTask.description(flavor, buildType))
       task.flavor = flavor
       task.buildType = buildType
       task.appId = appId
@@ -172,8 +174,12 @@ class ShotPlugin extends Plugin[Project] {
         task.dependsOn(removeScreenshots)
       }
 
-      downloadScreenshots.configure { task => task.mustRunAfter(instrumentationTask) }
-      removeScreenshots.configure { task => task.mustRunAfter(downloadScreenshots) }
+      downloadScreenshots.configure { task =>
+        task.mustRunAfter(instrumentationTask)
+      }
+      removeScreenshots.configure { task =>
+        task.mustRunAfter(downloadScreenshots)
+      }
     }
     baseTask.configure { task =>
       task.dependsOn(executeScreenshot)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #128
* **Related pull-requests:** none

### :tophat: What is the goal?

Reduce configuration time of every project that uses Shot. This is achieved by avoiding immediate task creation. 

### How is it being implemented?
Replace immediate task creation (`tasks.create`) with a lazy configuration (`tasks.register` + `taskProvider.configure`).
Implementation is based on Gradle recommendations for task avoidance: https://docs.gradle.org/current/userguide/task_configuration_avoidance.html

### How can it be tested?

Execute `./gradlew help --scan` inside `shot-consumer` folder and check how many tasks are created by `Shot` plugin under "Performance" -> "Configuration" tab in the build scan report.

Before changes ([see build scan report](https://scans.gradle.com/s/flqilmsk3ouuy/performance/configuration?focused=20&openScriptsAndPlugins=WzFd)) 17 tasks are created immediately where 12 tasks are created by Shot plugin.

After changes ([see build scan report](https://scans.gradle.com/s/ffaycqgfauuog/performance/configuration?focused=20&openScriptsAndPlugins=WzFd)) only 5 tasks are created immediately where 0 tasks are created by Shot plugin.
