### PR TITLE
Update Facebook library version to be able to disable accessibility features which are breaking the dialogs screenshots

### DIFF
--- a/shot-android/build.gradle
+++ b/shot-android/build.gradle
@@ -32,7 +32,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "com.facebook.testing.screenshot:core:0.12.0"
+    implementation "com.facebook.testing.screenshot:core:0.13.0"
     implementation "androidx.test:runner:1.2.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.test.espresso:espresso-core:3.2.0"

--- a/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
+++ b/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
@@ -128,6 +128,7 @@ interface ScreenshotTest {
         try {
             Screenshot
                 .snap(view)
+                .setIncludeAccessibilityInfo(false)
                 .setName(snapshotName)
                 .record()
         } catch (t: Throwable) {
@@ -141,6 +142,7 @@ interface ScreenshotTest {
         try {
             Screenshot
                 .snapActivity(activity)
+                .setIncludeAccessibilityInfo(false)
                 .setName(snapshotName)
                 .record()
         } catch (t: Throwable) {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #131

### :tophat: What is the goal?

Update Facebook library and disable the broken feature. More information can be found in the following links:

* https://github.com/facebook/screenshot-tests-for-android/issues/248
* https://github.com/facebook/screenshot-tests-for-android/pull/250
* https://github.com/facebook/screenshot-tests-for-android/pull/249

### How is it being implemented?

We've just changed the ``shot-android`` module to update the dependency and then we've updated ``ScreenshotTest`` interface to configure the screenshot builder with the ``setIncludeAccessibilityInfo`` param as ``false``.

### How can it be tested?

This can not automatically be tested because it is a feature we've fixed in Facebook's library and adding a test to ensure the builder is properly configured is not worth it. The already implemented coverage will ensure the project is working as expected. Proper code coverage has been added to the previously mentioned pull requests.