### PR TITLE
Use ANDOROID_SERIAL env var when it is declared

### DIFF
--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -131,7 +131,7 @@ class Shot(adb: Adb,
     adb.clearScreenshots(device, appId)
   }
 
-  private def forEachDevice[T](f: (String => T)) = devices.foreach(f)
+  private def forEachDevice[T](f: String => T): Unit = devices().foreach(f)
 
   private def devices(): List[String] = {
     val allDevices = adb.devices

--- a/core/src/main/scala/com/karumi/shot/system/EnvVars.scala
+++ b/core/src/main/scala/com/karumi/shot/system/EnvVars.scala
@@ -2,5 +2,9 @@ package com.karumi.shot.system
 
 class EnvVars {
   def androidSerial: Option[String] =
-    Option(sys.env("ANDROID_SERIAL")).filter(_.isEmpty)
+    try {
+      Option(sys.env("ANDROID_SERIAL")).filter(!_.isEmpty)
+    } catch {
+      case _: Throwable => None
+    }
 }

--- a/core/src/main/scala/com/karumi/shot/system/EnvVars.scala
+++ b/core/src/main/scala/com/karumi/shot/system/EnvVars.scala
@@ -1,0 +1,6 @@
+package com.karumi.shot.system
+
+class EnvVars {
+  def androidSerial: Option[String] =
+    Option(sys.env("ANDROID_SERIAL")).filter(_.isEmpty)
+}

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -13,6 +13,7 @@ import com.karumi.shot.screenshots.{
   ScreenshotsDiffGenerator,
   ScreenshotsSaver
 }
+import com.karumi.shot.system.EnvVars
 import com.karumi.shot.tasks.{
   DownloadScreenshotsTask,
   ExecuteScreenshotTests,
@@ -36,7 +37,8 @@ class ShotPlugin extends Plugin[Project] {
       new ScreenshotsSaver,
       console,
       new ExecutionReporter,
-      new ConsoleReporter(console)
+      new ConsoleReporter(console),
+      new EnvVars()
     )
 
   override def apply(project: Project): Unit = {

--- a/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
+++ b/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
@@ -9,6 +9,7 @@ import com.karumi.shot.screenshots.{
   ScreenshotsDiffGenerator,
   ScreenshotsSaver
 }
+import com.karumi.shot.system.EnvVars
 import com.karumi.shot.ui.Console
 import com.karumi.shot.{Files, Shot, ShotExtension}
 import org.gradle.api.{DefaultTask, GradleException}
@@ -28,7 +29,8 @@ abstract class ShotTask extends DefaultTask {
       new ScreenshotsSaver,
       console,
       new ExecutionReporter,
-      new ConsoleReporter(console)
+      new ConsoleReporter(console),
+      new EnvVars()
     )
   protected val shotExtension: ShotExtension =
     getProject.getExtensions.findByType(classOf[ShotExtension])


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #130

### :tophat: What is the goal?

Update the plugin flow to review if the ``ANDROID_SERIAL`` env var is configured before interacting with the devices.

### How is it being implemented?

We've created a class to handle environment variables and also added some extra behavior to check how many devices are connected. Whenever the variable is present, we've altered the plugin flow to use only the specified device instead of all the available devices. Last but not least, I've added coverage to the feature in order to ensure everything is working as expected.

### How can it be tested?

🤖 