### PR TITLE
Jetpack Compose support public API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
 
-    ext.kotlin_version = "1.3.31"
+    ext.kotlin_version = "1.3.50"
 
     dependencies {
         classpath "gradle.plugin.com.github.maiflai:gradle-scalatest:0.25"

--- a/shot-android/build.gradle
+++ b/shot-android/build.gradle
@@ -36,4 +36,5 @@ dependencies {
     implementation "androidx.test:runner:1.2.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.test.espresso:espresso-core:3.2.0"
+    implementation "androidx.ui:ui-test:1.0.0-alpha03"
 }

--- a/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
+++ b/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
@@ -19,7 +19,6 @@ import com.facebook.testing.screenshot.Screenshot
 import com.facebook.testing.screenshot.ViewHelpers
 import com.facebook.testing.screenshot.internal.TestNameDetector
 import androidx.ui.test.SemanticsNodeInteraction
-import com.karumi.shot.compose.ComposeScreenshot
 
 interface ScreenshotTest {
 
@@ -106,7 +105,6 @@ interface ScreenshotTest {
         disableFlakyComponentsAndWaitForIdle()
         val testName = name ?: TestNameDetector.getTestName()
         val snapshotName = "${TestNameDetector.getTestClass()}_$testName"
-
     }
 
     fun disableFlakyComponentsAndWaitForIdle(view: View? = null) {

--- a/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
+++ b/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
@@ -18,6 +18,8 @@ import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.facebook.testing.screenshot.Screenshot
 import com.facebook.testing.screenshot.ViewHelpers
 import com.facebook.testing.screenshot.internal.TestNameDetector
+import androidx.ui.test.SemanticsNodeInteraction
+import com.karumi.shot.compose.ComposeScreenshot
 
 interface ScreenshotTest {
 
@@ -100,10 +102,19 @@ interface ScreenshotTest {
         takeViewSnapshot(name, view)
     }
 
-    fun disableFlakyComponentsAndWaitForIdle(view: View) {
+    fun compareScreenshot(node: SemanticsNodeInteraction, name: String? = null) {
+        disableFlakyComponentsAndWaitForIdle()
+        val testName = name ?: TestNameDetector.getTestName()
+        val snapshotName = "${TestNameDetector.getTestClass()}_$testName"
+
+    }
+
+    fun disableFlakyComponentsAndWaitForIdle(view: View? = null) {
         prepareUIForScreenshot()
-        disableAnimatedComponents(view)
-        hideIgnoredViews(view)
+        if (view != null) {
+            disableAnimatedComponents(view)
+            hideIgnoredViews(view)
+        }
         waitForAnimationsToFinish()
     }
 

--- a/shot-android/src/main/java/com/karumi/shot/compose/ComposeScreenshot.kt
+++ b/shot-android/src/main/java/com/karumi/shot/compose/ComposeScreenshot.kt
@@ -1,0 +1,3 @@
+package com.karumi.shot.compose
+
+class ComposeScreenshot

--- a/shot-consumer-compose/app/build.gradle
+++ b/shot-consumer-compose/app/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.+'
 
+    androidTestImplementation("androidx.ui:ui-test:$compose_version")
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test:core-ktx:1.3.0'
     androidTestImplementation 'androidx.test:core:1.3.0'

--- a/shot-consumer-compose/app/build.gradle
+++ b/shot-consumer-compose/app/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.+'
 
-    androidTestImplementation("androidx.ui:ui-test:$compose_version")
+    androidTestImplementation "androidx.ui:ui-test:$compose_version"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test:core-ktx:1.3.0'
     androidTestImplementation 'androidx.test:core:1.3.0'

--- a/shot-consumer-compose/app/src/androidTest/java/com/karumi/shotconsumercompose/GreetingScreenshotTest.kt
+++ b/shot-consumer-compose/app/src/androidTest/java/com/karumi/shotconsumercompose/GreetingScreenshotTest.kt
@@ -7,6 +7,7 @@ import androidx.ui.test.createComposeRule
 import com.karumi.shot.ScreenshotTest
 import com.karumi.shotconsumercompose.ui.ShotConsumerComposeTheme
 import org.junit.Rule
+import androidx.ui.test.onRoot
 import org.junit.Test
 
 class GreetingScreenshotTest : ScreenshotTest {
@@ -16,25 +17,32 @@ class GreetingScreenshotTest : ScreenshotTest {
 
     @Test
     fun rendersTheDefaultComponent() {
-        composeRule.setContent {
-            DefaultPreview()
-        }
+        renderComponent()
+        compareScreenshot(composeRule.onRoot())
+    }
+
+    @Test
+    fun rendersAGreetingWithAnEmptyText() {
+        renderComponent("")
+        compareScreenshot(composeRule.onRoot())
+    }
+
+    @Test
+    fun rendersAGreetingWithATextFullOfWhitespaces() {
+        renderComponent(" ".repeat(200))
+        compareScreenshot(composeRule.onRoot())
     }
 
     @Test
     fun rendersAGreetingWithAShortText() {
-        val greeting = "Hello!"
-        composeRule.setContent {
-            greetingComponent(greeting)
-        }
+        renderComponent("Hello!")
+        compareScreenshot(composeRule.onRoot())
     }
 
     @Test
     fun rendersAGreetingWithALongText() {
-        val greeting = "Hello world from the compose!".repeat(20)
-        composeRule.setContent {
-            greetingComponent(greeting)
-        }
+        renderComponent("Hello world from the compose!".repeat(20))
+        compareScreenshot(composeRule.onRoot())
     }
 
     @Composable
@@ -45,4 +53,15 @@ class GreetingScreenshotTest : ScreenshotTest {
             }
         }
     }
+
+    private fun renderComponent(greeting: String? = null) {
+        composeRule.setContent {
+            if (greeting == null) {
+                DefaultPreview()
+            } else {
+                greetingComponent(greeting)
+            }
+        }
+    }
+
 }

--- a/shot-consumer-compose/app/src/androidTest/java/com/karumi/shotconsumercompose/GreetingScreenshotTest.kt
+++ b/shot-consumer-compose/app/src/androidTest/java/com/karumi/shotconsumercompose/GreetingScreenshotTest.kt
@@ -1,0 +1,48 @@
+package com.karumi.shotconsumercompose
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.ui.test.createComposeRule
+import com.karumi.shot.ScreenshotTest
+import com.karumi.shotconsumercompose.ui.ShotConsumerComposeTheme
+import org.junit.Rule
+import org.junit.Test
+
+class GreetingScreenshotTest : ScreenshotTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun rendersTheDefaultComponent() {
+        composeRule.setContent {
+            DefaultPreview()
+        }
+    }
+
+    @Test
+    fun rendersAGreetingWithAShortText() {
+        val greeting = "Hello!"
+        composeRule.setContent {
+            greetingComponent(greeting)
+        }
+    }
+
+    @Test
+    fun rendersAGreetingWithALongText() {
+        val greeting = "Hello world from the compose!".repeat(20)
+        composeRule.setContent {
+            greetingComponent(greeting)
+        }
+    }
+
+    @Composable
+    private fun greetingComponent(greeting: String) {
+        ShotConsumerComposeTheme {
+            Surface(color = MaterialTheme.colors.background) {
+                Greeting(greeting)
+            }
+        }
+    }
+}

--- a/shot-consumer-compose/app/src/main/AndroidManifest.xml
+++ b/shot-consumer-compose/app/src/main/AndroidManifest.xml
@@ -20,6 +20,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name="androidx.activity.ComponentActivity" />
+
     </application>
 
 </manifest>

--- a/shot-consumer-compose/build.gradle
+++ b/shot-consumer-compose/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.0-alpha02'
+        compose_version = '1.0.0-alpha03'
     }
     ext.kotlin_version = "1.4.10"
     repositories {

--- a/shot-consumer-flavors/app/build.gradle
+++ b/shot-consumer-flavors/app/build.gradle
@@ -23,7 +23,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.karumi"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -71,8 +71,8 @@ dependencies {
     implementation "com.github.salomonbrys.kodein:kodein-conf:4.1.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.squareup.picasso:picasso:2.5.2"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9"
     implementation "android.arch.lifecycle:extensions:1.1.1"
     annotationProcessor "android.arch.lifecycle:compiler:1.1.1"
 

--- a/shot-consumer-flavors/build.gradle
+++ b/shot-consumer-flavors/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.40'
+    ext.kotlin_version = '1.4.10'
     repositories {
         google()
         jcenter()

--- a/shot-consumer/app/build.gradle
+++ b/shot-consumer/app/build.gradle
@@ -23,7 +23,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.karumi"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -57,8 +57,8 @@ dependencies {
     implementation "com.github.salomonbrys.kodein:kodein-conf:4.1.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.squareup.picasso:picasso:2.5.2"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9"
     implementation "android.arch.lifecycle:extensions:1.1.1"
     annotationProcessor "android.arch.lifecycle:compiler:1.1.1"
 

--- a/shot-consumer/app2/build.gradle
+++ b/shot-consumer/app2/build.gradle
@@ -23,7 +23,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.karumi"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/shot-consumer/build.gradle
+++ b/shot-consumer/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.10'
     repositories {
         mavenLocal()
         mavenCentral()

--- a/shot-consumer/build.gradle
+++ b/shot-consumer/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
-    ext.kotlin_version = '1.3.40'
+    ext.kotlin_version = '1.3.50'
     repositories {
+        mavenLocal()
+        mavenCentral()
         google()
         jcenter()
         maven { url uri('../repo') }
@@ -14,6 +16,8 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
+        mavenCentral()
         google()
         jcenter()
         maven { url uri('../../repo') }

--- a/shot-consumer/samplelibrary/build.gradle
+++ b/shot-consumer/samplelibrary/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.karumi.samplelibrary.test.app.id"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #136

### :tophat: What is the goal?

Define the public API we are going to provide to be able to take a screenshot of a Jetpack Compose component. This will be the API we will provide for the first version.

### How is it being implemented?

We've just added a new entry point in our ``ScreenshotTests`` interface accepting a ``SemanticsNodeInteraction`` which is the top type we will use in order to interact with Compose. To be able to do this we've updated the compose version up to alpha3 and also changed how ``disableFlakyComponentsAndWaitForIdle`` works to accept a nullable view. Once this was ready, we wrote some tests for the only component we have right now so you can see how the public API will be used.

Disclaimer: ``compareScreenshot`` behavior is not implemented for now. This will be part of my next PR.

### How can it be tested?

🤖 
