### PR TITLE
Correct Android source property in release.gradle

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -84,7 +84,7 @@ afterEvaluate { project ->
     if (isAndroidProject) {
         task androidSourcesJar(type: Jar) {
             classifier = 'sources'
-            from android.sourceSets.main.java.sourceFiles
+            from android.sourceSets.main.java.srcDirs
         }
 
         artifacts {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Fixes #139 

### :tophat: What is the goal?

Ensure the sources jar distributed with shot-android contains shot-android's sources.

### How is it being implemented?

In release.gradle, replace "android.sourceSets.main.java.sourceFiles" with "android.sourceSets.main.java.srcDirs" as the property defining the location of the source files for Android modules.

### How can it be tested?

Run `./gradlew androidSourcesJar`. Navigate to shot-android/build/lib and unzip the generated sources jar. Observe that it contains the module's source files, e.g. ScreenshotTest.kt.

- [ ] **Use case 1:** As a shot-android consumer, I want to navigate through shot-android sources within my IDE so I can more easily understand shot-android's behavior in my test suite.