### PR TITLE
Improve error handling when there are only compose screenshots

### DIFF
--- a/core/src/main/scala/com/karumi/shot/Files.scala
+++ b/core/src/main/scala/com/karumi/shot/Files.scala
@@ -9,8 +9,14 @@ import org.apache.commons.io.FileUtils
 import scala.io.Source
 
 class Files {
-  def listFilesInFolder(folder: FilePath): util.Collection[File] =
-    FileUtils.listFiles(new File(folder), null, false)
+  def listFilesInFolder(folder: FilePath): util.Collection[File] = {
+    val file = new File(folder)
+    if (file.exists()) {
+      FileUtils.listFiles(file, null, false)
+    } else {
+      util.Collections.emptyList()
+    }
+  }
 
   def rename(origin: FilePath, target: FilePath): Unit = {
     val originFile = new File(origin)

--- a/core/src/main/scala/com/karumi/shot/Files.scala
+++ b/core/src/main/scala/com/karumi/shot/Files.scala
@@ -12,8 +12,12 @@ class Files {
   def listFilesInFolder(folder: FilePath): util.Collection[File] =
     FileUtils.listFiles(new File(folder), null, false)
 
-  def rename(origin: FilePath, target: FilePath): Unit =
-    FileUtils.moveFile(new File(origin), new File(target))
+  def rename(origin: FilePath, target: FilePath): Unit = {
+    val originFile = new File(origin)
+    if (originFile.exists()) {
+      FileUtils.moveFile(originFile, new File(target))
+    }
+  }
 
   def read(filePath: FilePath): String =
     Source.fromFile(filePath, "UTF8").getLines.mkString


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #136 

### :tophat: What is the goal?

Fix a bug found while using Shot in projects where there are only compose screenshot tests.

### How is it being implemented?

We've changed the way we pull the screenshots to show a warning if there is something wrong and also the code renaming the metadata files to be safer and do nothing if the source file does not exist.

### How can it be tested?

🤖 