### PR TITLE
Provide activity scenario support

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,23 @@ dependencies {
 
 Keep in mind you'll need to use a compatible version or Shot won't work as expected.
 
+## ActivityScenario support
+
+``ActivityTestRule`` has been deprecated and now the usage of ActivityScenario is recommended. However, Shot needs to be executed from the instrumentation thread to be able to extract all the test metadata needed to record and verify screenshots. That's why we've created an ``ActivityScenario`` extension method named ``waitForActivity``. This extension is needed get the activity instance from the instrumentation thread instead of running Shot from the app target thread. Using this extension you can write tests like this:
+
+```kotlin
+class MainActivityTest: ScreenshotTest {
+    @Test
+    fun rendersTheDefaultActivityState() {
+        val activity = ActivityScenario.launch(MainActivity::class.java)
+
+        compareScreenshot(activity)
+    }
+}
+```
+
+I hope we can find a better solution for this issue in the future.
+
 ## Recording tests
 
 You can record your screenshot tests executing this command:

--- a/shot-android/src/main/java/com/karumi/shot/ActivityScenarioUtils.kt
+++ b/shot-android/src/main/java/com/karumi/shot/ActivityScenarioUtils.kt
@@ -1,0 +1,23 @@
+package com.karumi.shot
+
+import android.app.Activity
+import androidx.test.core.app.ActivityScenario
+import java.lang.IllegalStateException
+
+/* ActivityTestRule has been deprecated and now the usage of ActivityScenario is recommended.
+ * However, Shot needs to be executed from the instrumentation thread to be able to extract
+ * all the test metadata needed to record and verify screenshots. That's why we've created this
+ * extension to be able to get the activity instance from the instrumentation thread instead
+ * of running Shot from the app target thread. I hope we can find a better solution in the future.
+ */
+fun <A : Activity> ActivityScenario<A>.waitForActivity(): A {
+    var activity: A? = null
+    onActivity {
+        activity = it
+    }
+    return if (activity != null) {
+        activity!!
+    } else {
+        throw IllegalStateException("The activity scenario could not be initialized.")
+    }
+}

--- a/shot-consumer-flavors/app/build.gradle
+++ b/shot-consumer-flavors/app/build.gradle
@@ -78,12 +78,12 @@ dependencies {
 
     testImplementation "junit:junit:4.12"
 
-    androidTestImplementation "androidx.test:runner:1.2.0"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
-    androidTestImplementation "androidx.test.espresso:espresso-intents:3.2.0"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:3.2.0"
-    androidTestImplementation "androidx.test:rules:1.2.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.1"
+    androidTestImplementation "androidx.test:runner:1.3.0"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
+    androidTestImplementation "androidx.test.espresso:espresso-intents:3.3.0"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:3.3.0"
+    androidTestImplementation "androidx.test:rules:1.3.0"
+    androidTestImplementation "androidx.test.ext:junit:1.1.2"
     androidTestImplementation "asm:asm:3.3.1"
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.1.1"
     androidTestImplementation "com.github.tmurakami:dexopener:2.0.0"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #135 

### :tophat: What is the goal?

Provide ``ActivityScenarioSupport``.

### How is it being implemented?

To implement this feature we've done our best...but the result is far from perfect 😢  The key to understanding this PR is to know the code extracting the class name and test name needs to be in the instrumentation thread. If we try to find the test name from the target app main thread the result will not be correct. So what did we do to solve this issue? We've created an extension method in ``ActivityScenario`` to be able to wait for the activity and return the instance to the instrumentation test thread. Just in case something changes the future we've also updated the code handling threads to ensure everything works as expected. Last but not least, we've changed one of the consumers to use ``ActivityScenario`` so we can use this consumer as an end-to-end test scenario and updated our documentation

### How can it be tested?

🤖 