### PR TITLE
#161

### DIFF
--- a/shot-android/src/androidTest/java/com/karumi/shot/compose/ScreenshotSaverTest.kt
+++ b/shot-android/src/androidTest/java/com/karumi/shot/compose/ScreenshotSaverTest.kt
@@ -3,6 +3,7 @@ package com.karumi.shot.compose
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.filters.SdkSuppress
 import androidx.test.rule.GrantPermissionRule
 import com.nhaarman.mockitokotlin2.whenever
 import junit.framework.TestCase.assertEquals
@@ -51,6 +52,7 @@ class ScreenshotSaverTest {
         clearSdCardFiles()
     }
 
+    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun savesTheBitmapObtainedFromTheNodeUsingTheScreenshotMetadata() {
         saver.saveScreenshot(screenshotToSave)
@@ -59,6 +61,7 @@ class ScreenshotSaverTest {
         assertTrue(file.exists())
     }
 
+    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun savesAllTheBitmapsObtainedFromTheNodeUsingTheScreenshotMetadata() {
         val testsMetadata = listOf(screenshotToSave, otherScreenshotToSave)
@@ -72,6 +75,7 @@ class ScreenshotSaverTest {
         })
     }
 
+    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun savesScreenshotTestsExecutionMetadataInAJsonFile() {
         val session = ScreenshotTestSession().add(screenshotToSave.data).add(otherScreenshotToSave.data)
@@ -85,6 +89,7 @@ class ScreenshotSaverTest {
         assertEquals(expectedContent, content)
     }
 
+    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun savesTheBitmapsAndTheMetadataAfterTheTestsExecution() {
         val session = ScreenshotTestSession().add(screenshotToSave.data)

--- a/shot-android/src/main/java/com/karumi/shot/compose/ComposeScreenshot.kt
+++ b/shot-android/src/main/java/com/karumi/shot/compose/ComposeScreenshot.kt
@@ -17,7 +17,10 @@ class ComposeScreenshot(
     }
 
     fun saveMetadata(): ScreenshotTestSession {
-        saver.saveMetadata(session)
+        // If there's nothing to save, don't attempt to at all:
+        if (session.getScreenshotSessionMetadata().screenshotsData.isNotEmpty()) {
+            saver.saveMetadata(session)
+        }
         return session
     }
 }

--- a/shot-android/src/main/java/com/karumi/shot/compose/ScreenshotSaver.kt
+++ b/shot-android/src/main/java/com/karumi/shot/compose/ScreenshotSaver.kt
@@ -5,7 +5,6 @@ import android.graphics.Bitmap
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.ui.test.SemanticsNodeInteraction
 import com.google.gson.Gson
 import java.io.File

--- a/shot-android/src/main/java/com/karumi/shot/compose/ScreenshotSaver.kt
+++ b/shot-android/src/main/java/com/karumi/shot/compose/ScreenshotSaver.kt
@@ -3,7 +3,9 @@ package com.karumi.shot.compose
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.ui.test.SemanticsNodeInteraction
 import com.google.gson.Gson
 import java.io.File
@@ -18,12 +20,22 @@ class ScreenshotSaver(private val packageName: String, private val bitmapGenerat
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun saveScreenshot(screenshot: ScreenshotToSave) {
+        if (Build.VERSION.SDK_INT >= 29) {
+            Log.w("Shot", "Can't save screenshot bitmap on Android OS ${Build.VERSION.SDK_INT}")
+            return
+        }
+
         val bitmap = bitmapGenerator.generateBitmap(screenshot)
         createScreenshotsFolderIfDoesNotExist()
         saveScreenshotBitmap(bitmap, screenshot.data)
     }
 
     fun saveMetadata(session: ScreenshotTestSession) {
+        if (Build.VERSION.SDK_INT >= 29) {
+            Log.w("Shot", "Can't save metadata file on Android OS ${Build.VERSION.SDK_INT}")
+            return
+        }
+
         createScreenshotsFolderIfDoesNotExist()
         val metadata = session.getScreenshotSessionMetadata()
         val serializedMetadata = gson.toJson(metadata)
@@ -63,6 +75,9 @@ class ScreenshotSaver(private val packageName: String, private val bitmapGenerat
         }
     }
 
+    /**
+     * Creates a file at [path] using the [File] API (does not work on API 29+).
+     */
     private fun createFileIfNotExists(path: String): File {
         val file = File(path)
         if (!file.exists()) {

--- a/shot-android/src/main/java/com/karumi/shot/compose/ScreenshotTestSession.kt
+++ b/shot-android/src/main/java/com/karumi/shot/compose/ScreenshotTestSession.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName
 class ScreenshotTestSession {
 
     companion object {
+        @Deprecated("ScreenshotTestSession is mutable and thus this instance cannot be guaranteed to be empty.")
         val empty: ScreenshotTestSession = ScreenshotTestSession()
     }
 

--- a/shot-android/src/test/java/com/karumi/shot/compose/ComposeScreenshotTest.kt
+++ b/shot-android/src/test/java/com/karumi/shot/compose/ComposeScreenshotTest.kt
@@ -1,11 +1,12 @@
 package com.karumi.shot.compose
 
 import androidx.ui.test.SemanticsNodeInteraction
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.*
 import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 
@@ -26,7 +27,7 @@ class ComposeScreenshotTest {
 
     @Before
     fun setUp() {
-        composeScreenshot = ComposeScreenshot(ScreenshotTestSession.empty, screenshotSaver)
+        composeScreenshot = ComposeScreenshot(ScreenshotTestSession(), screenshotSaver)
     }
 
     @Test
@@ -35,8 +36,8 @@ class ComposeScreenshotTest {
 
         composeScreenshot.saveScreenshot(node, data)
 
-        val expectedSession = ScreenshotTestSession.empty.add(data)
-        assertEquals(expectedSession, composeScreenshot.saveMetadata())
+        val expectedSessionMetadata = ScreenshotSessionMetadata(listOf(data))
+        assertEquals(expectedSessionMetadata, composeScreenshot.saveMetadata().getScreenshotSessionMetadata())
     }
 
     @Test
@@ -57,10 +58,20 @@ class ComposeScreenshotTest {
         composeScreenshot.saveScreenshot(node, data)
         composeScreenshot.saveMetadata()
 
-        val expectedSession = ScreenshotTestSession.empty
-                .add(data)
-                .add(data)
-                .add(data)
-        verify(screenshotSaver).saveMetadata(expectedSession)
+        val captor = argumentCaptor<ScreenshotTestSession>()
+        verify(screenshotSaver).saveMetadata(captor.capture())
+
+        val actualSession = captor.lastValue
+        val actualSessionMetadata = actualSession.getScreenshotSessionMetadata()
+        assertEquals(3, actualSessionMetadata.screenshotsData.size)
+        for (i in 0 until 3) {
+            assertEquals(data, actualSessionMetadata.screenshotsData[i])
+        }
+    }
+
+    @Test
+    fun whenNoScreenshotsWereSavedTheMetadataIsNotSaved() {
+        composeScreenshot.saveMetadata()
+        verify(screenshotSaver, never()).saveMetadata(any())
     }
 }

--- a/shot-android/src/test/java/com/karumi/shot/compose/ComposeScreenshotTest.kt
+++ b/shot-android/src/test/java/com/karumi/shot/compose/ComposeScreenshotTest.kt
@@ -6,7 +6,6 @@ import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #161 

### :tophat: What is the goal?

Allow instrumented tests using ShotTestRunner to pass on API 29+

### How is it being implemented?

1. Don't attempt to save a Compose metadata file to the device if no Compose screenshots have been taken.
2. Don't attempt to save Compose metadata or screenshots to the device if the OS version is 29+.

### How can it be tested?

Run `./gradlew connectedCheck` on a project using ShotTestRunner on an API 29+ device. The test suite should pass.
