### PR TITLE
Shot Working on API 29+ in some cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,13 +290,20 @@ You can run a single test or test class, just add the `android.testInstrumentati
 
 ## Using shot on API 29+
 
-Due to the new storage system implemented on API 29 and higher, Shot is unable to write the screenshots on the SD. Shot can't be used at the moment with apps whose ``Target SDK is >= 30`` over ``devices with API >= 30``.
+Due to the new storage system implemented on API 29 and higher, Shot has some limitations writing the screenshots on the SD. *Shot can't be used when both ``Target SDK`` and ``device API`` are API 30.*
 
 If one of those values (Target SDK or Device API) is <= 29,  Shot will work properly just adding the following parameter in the ``AndroidManifest.xml`` of the test app.
 
 ```
 <application android:requestLegacyExternalStorage="true" />
 ```
+
+The following combination should work properly using the previous flag:
+| Target SDK  | Device API  | RequestLegacyExternalStorage |
+|-------------|------------|----------------------------------|
+| 30 | 29  | true  |
+| 29 | 29  | true  |
+| 29 | 30  | true  |
 
 ## Development documentation
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,16 @@ You can run a single test or test class, just add the `android.testInstrumentati
 ./gradlew <Flavor><BuildType>executeScreenshotTests -Pandroid.testInstrumentationRunnerArguments.class=com.your.package.YourClassTest#yourTest
 ```
 
+## Using shot on API 29+
+
+Due to the new storage system implemented on API 29 and higher, Shot is unable to write the screenshots on the SD. Shot can't be used at the moment with apps whose ``Target SDK is >= 30`` over ``devices with API >= 30``.
+
+If one of those values (Target SDK or Device API) is <= 29,  Shot will work properly just adding the following parameter in the ``AndroidManifest.xml`` of the test app.
+
+```
+<application android:requestLegacyExternalStorage="true" />
+```
+
 ## Development documentation
 
 Inside this repository you'll find two types of projects. The first one is all the code related to the Gradle Plugin. The second one is all the code related to the example projects we use as consumers of the Gradle Plugin and also as end to end tests. Review the following folders when developing a new feature for Shot or fixing a bug:

--- a/shot-android/src/androidTest/java/com/karumi/shot/compose/ScreenshotSaverTest.kt
+++ b/shot-android/src/androidTest/java/com/karumi/shot/compose/ScreenshotSaverTest.kt
@@ -3,7 +3,6 @@ package com.karumi.shot.compose
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.filters.SdkSuppress
 import androidx.test.rule.GrantPermissionRule
 import com.nhaarman.mockitokotlin2.whenever
 import junit.framework.TestCase.assertEquals
@@ -52,7 +51,6 @@ class ScreenshotSaverTest {
         clearSdCardFiles()
     }
 
-    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun savesTheBitmapObtainedFromTheNodeUsingTheScreenshotMetadata() {
         saver.saveScreenshot(screenshotToSave)
@@ -61,7 +59,6 @@ class ScreenshotSaverTest {
         assertTrue(file.exists())
     }
 
-    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun savesAllTheBitmapsObtainedFromTheNodeUsingTheScreenshotMetadata() {
         val testsMetadata = listOf(screenshotToSave, otherScreenshotToSave)
@@ -75,7 +72,6 @@ class ScreenshotSaverTest {
         })
     }
 
-    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun savesScreenshotTestsExecutionMetadataInAJsonFile() {
         val session = ScreenshotTestSession().add(screenshotToSave.data).add(otherScreenshotToSave.data)
@@ -89,7 +85,6 @@ class ScreenshotSaverTest {
         assertEquals(expectedContent, content)
     }
 
-    @SdkSuppress(maxSdkVersion = 28)
     @Test
     fun savesTheBitmapsAndTheMetadataAfterTheTestsExecution() {
         val session = ScreenshotTestSession().add(screenshotToSave.data)

--- a/shot-android/src/main/java/com/karumi/shot/compose/ScreenshotSaver.kt
+++ b/shot-android/src/main/java/com/karumi/shot/compose/ScreenshotSaver.kt
@@ -19,9 +19,9 @@ class ScreenshotSaver(private val packageName: String, private val bitmapGenerat
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun saveScreenshot(screenshot: ScreenshotToSave) {
-        if (Build.VERSION.SDK_INT >= 29) {
-            Log.w("Shot", "Can't save screenshot bitmap on Android OS ${Build.VERSION.SDK_INT}")
-            return
+        if (Build.VERSION.SDK_INT >= 30) {
+            Log.w("Shot", "Can't save screenshot bitmap on Android OS ${Build.VERSION.SDK_INT} on applications with Target SDK >= 30." +
+                    "If your app has Target SDK <= 29, you should add \"android:requestLegacyExternalStorage=\"true\"\" on your test manifest.")
         }
 
         val bitmap = bitmapGenerator.generateBitmap(screenshot)
@@ -30,9 +30,9 @@ class ScreenshotSaver(private val packageName: String, private val bitmapGenerat
     }
 
     fun saveMetadata(session: ScreenshotTestSession) {
-        if (Build.VERSION.SDK_INT >= 29) {
-            Log.w("Shot", "Can't save metadata file on Android OS ${Build.VERSION.SDK_INT}")
-            return
+        if (Build.VERSION.SDK_INT >= 30) {
+            Log.w("Shot", "Can't save screenshot bitmap on Android OS ${Build.VERSION.SDK_INT} on applications with Target SDK >= 30." +
+                    "If your app has Target SDK <= 29, you should add \"android:requestLegacyExternalStorage=\"true\"\" on your test manifest.")
         }
 
         createScreenshotsFolderIfDoesNotExist()
@@ -75,7 +75,14 @@ class ScreenshotSaver(private val packageName: String, private val bitmapGenerat
     }
 
     /**
-     * Creates a file at [path] using the [File] API (does not work on API 29+).
+     * Creates a file at [path] using the [File] API.
+     * When API 29+ is the target SDK or the Device API not all combinations all available.
+     * This will work with the following combinations:
+     * | APP Target SDK | Device API | requestLegacyExternalStorage (Manifest) |
+     *          30     |      29     |             true                        |
+     *          29     |      29     |             true                        |
+     *          29     |      30     |             true                        |
+     * This method can't work on apps with Target SDK >= 30 and devices with API >= 30.
      */
     private fun createFileIfNotExists(path: String): File {
         val file = File(path)

--- a/shot-consumer-compose/app/src/androidTest/AndroidManifest.xml
+++ b/shot-consumer-compose/app/src/androidTest/AndroidManifest.xml
@@ -5,4 +5,6 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
+    <application android:requestLegacyExternalStorage="true" />
+
 </manifest>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #120 

### :tophat: What is the goal?

Due to the new storage system implemented on API 29 and higher, Shot is unable to write the screenshots on the SD. Shot can't be used at the moment with apps whose ``Target SDK is >= 30`` over ``devices with API >= 30``.

If one of those values (Target SDK or Device API) is <= 29,  Shot will work properly just adding the following parameter in the ``AndroidManifest.xml`` of the test app.

```
<application android:requestLegacyExternalStorage="true" />
```

A solution for Target SDK 30 and Device API 30 (an higher) execution is needed :S.

More information could be found in:
https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage

### How is it being implemented?

Just removed the harcoded limitation when Shot is working on Devices with API higher than 28.

### How can it be tested?

Running screenshot tests over different combinations of Target SDK and Device API

| Target SDK  | Device API  | RequestLegacyExternalStorage  | Result  |
|-------------|------------|----------------------------------|--------|
| 30 | 30  | true  | ❌ | 
| 30 | 30  | false | ❌ |
| 30 | 29  | true  | ✅ | 
| 30 | 29  | false | ❌ |
| 29 | 29  | true  | ✅ | 
| 29 | 29  | false | ❌ |
| 29 | 30  | true  | ✅ | 
| 29 | 30  | false | ❌ |