### PR TITLE
Updated compose version to alpha12

### DIFF
--- a/shot-android/build.gradle
+++ b/shot-android/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation "androidx.test:runner:1.3.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.test.espresso:espresso-core:3.3.0"
-    implementation "androidx.compose.ui:ui-test-junit4:1.0.0-alpha11"
+    implementation "androidx.compose.ui:ui-test-junit4:1.0.0-alpha12"
     implementation "com.google.code.gson:gson:2.8.6"
 
     testImplementation "junit:junit:4.13"

--- a/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
+++ b/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
@@ -109,6 +109,7 @@ interface ScreenshotTest {
         takeViewSnapshot(name, view)
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     fun compareScreenshot(rule: ComposeTestRule, name: String? = null) {
         rule.waitForIdle()
         compareScreenshot(rule.onRoot(), name)

--- a/shot-consumer-compose/app/build.gradle
+++ b/shot-consumer-compose/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
+    implementation "androidx.activity:activity-compose:1.3.0-alpha02"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-beta01"
 
     testImplementation "junit:junit:4.13.1"

--- a/shot-consumer-compose/app/src/main/java/com/karumi/shotconsumercompose/MainActivity.kt
+++ b/shot-consumer-compose/app/src/main/java/com/karumi/shotconsumercompose/MainActivity.kt
@@ -1,9 +1,9 @@
 package com.karumi.shotconsumercompose
 
 import android.os.Bundle
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.setContent
 import com.karumi.shotconsumercompose.ui.ShotConsumerComposeTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
@@ -11,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Text
 import androidx.compose.ui.tooling.preview.Preview
 

--- a/shot-consumer-compose/build.gradle
+++ b/shot-consumer-compose/build.gradle
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.0-alpha11'
+        compose_version = '1.0.0-alpha12'
     }
-    ext.kotlin_version = "1.4.21-2"
+    ext.kotlin_version = "1.4.30"
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
### :tophat: What is the goal?

Updated compose version to lastest alpha. (alpha12), Also added a requires android O annotation to resolve a lint error following on from what had been done for another function

### How is it being implemented?

N/A

### How can it be tested?

Ran all the units tests seemed fine although I did expect to have to update the kotlin version to 1.4.30 but seemed happy with the current version.
