### PR TITLE
Fix crash after build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ This plugin sets up a few convenience commands you can list executing ``./gradle
 executeScreenshotTests - Checks the user interface screenshot tests. If you execute this task using -Precord param the screenshot will be regenerated.
 blueDebugDownloadScreenshots - Retrieves the screenshots stored into the Android device where the tests were executed for the build BlueDebug
 blueDebugExecuteScreenshotTests - Records the user interface tests screenshots. If you execute this task using -Precord param the screenshot will be regenerated for the build BlueDebug
-blueDebugRemoveScreenshots - Removes the screenshots recorded during the tests execution from the Android device where the tests were executed for the build BlueDebug
+blueDebugRemoveScreenshotsBefore - Removes the screenshots recorded before the tests execution from the Android device where the tests were executed for the build BlueDebug
+blueDebugRemoveScreenshotsAfter - Removes the screenshots recorded after the tests execution from the Android device where the tests were executed for the build BlueDebug
 greenDebugDownloadScreenshots - Retrieves the screenshots stored into the Android device where the tests were executed for the build GreenDebug
 greenDebugExecuteScreenshotTests - Records the user interface tests screenshots. If you execute this task using -Precord param the screenshot will be regenerated for the build GreenDebug
-greenDebugRemoveScreenshots - Removes the screenshots recorded during the tests execution from the Android device where the tests were executed for the build GreenDebug
+greenDebugRemoveScreenshotsBefore - Removes the screenshots recorded before the tests execution from the Android device where the tests were executed for the build GreenDebug
+greenDebugRemoveScreenshotsAfter - Removes the screenshots recorded after the tests execution from the Android device where the tests were executed for the build GreenDebug
 ```
 
 If for some reason you are running your tests on a different machine and you want to skip the instrumentation tests execution and just compare the sources remember you can use the following shot configuration:

--- a/README.md
+++ b/README.md
@@ -257,11 +257,15 @@ or
 
 ## Executing tests from Android Studio
 
-Shot is a Gradle plugin and it does not integrate with AS by default. After running your tests, Shot Gradle plugin will fetch the screenshots generated during tests' execution and use them to check if your tests are passing or not. You always can run your tests from command linke as explained above. However, **if you want to run your tests from AS you can create a configuration like this**:
+Shot is a Gradle plugin and it does not integrate with AS by default. After running your tests, Shot Gradle plugin will fetch the screenshots generated during tests' execution and use them to check if your tests are passing or not. You always can run your tests from command line as explained above. However, **if you want to run your tests from AS you can create a configuration like this**:
 
 ![asConfig](./art/asConfig.png)
 
-Keep in mind the debugger may not work if use use this option. If you want to debug your tests you can run them from Android Studio as you'd do with any other instrumentation test.
+Keep in mind the debugger may not work if use use this option. If you want to debug your tests you can run them from Android Studio as you'd do with any other instrumentation test and you may need to execute this command before running your test:
+
+```
+adb rm -rf /storage/emulated/0/Download/screenshots/*
+```
 
 ## Executing tests in multiple devices
 

--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -140,11 +140,8 @@ class Shot(adb: Adb,
     comparison
   }
 
-  def removeScreenshots(appId: AppId): Unit = {
-    console.show(
-      "🧹  Cleaning the device folder where the screenshots are saved.")
+  def removeScreenshots(appId: AppId): Unit =
     clearScreenshots(appId)
-  }
 
   private def moveComposeScreenshotsToRegularScreenshotsFolder(
       projectFolder: Folder,

--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -140,8 +140,10 @@ class Shot(adb: Adb,
     comparison
   }
 
-  def removeScreenshots(appId: AppId): Unit =
+  def removeScreenshots(appId: AppId): Unit = {
+    console.show("🧹  Cleaning the device folder where the screenshots are saved.")
     clearScreenshots(appId)
+  }
 
   private def moveComposeScreenshotsToRegularScreenshotsFolder(
       projectFolder: Folder,

--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -141,7 +141,8 @@ class Shot(adb: Adb,
   }
 
   def removeScreenshots(appId: AppId): Unit = {
-    console.show("🧹  Cleaning the device folder where the screenshots are saved.")
+    console.show(
+      "🧹  Cleaning the device folder where the screenshots are saved.")
     clearScreenshots(appId)
   }
 

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -137,11 +137,13 @@ class ShotPlugin extends Plugin[Project] {
     }
     val tasks = project.getTasks
     val removeScreenshotsAfterExecution = tasks
-      .register(RemoveScreenshotsTask.name(flavor, buildType, beforeExecution = false),
-                classOf[RemoveScreenshotsTask])
+      .register(
+        RemoveScreenshotsTask.name(flavor, buildType, beforeExecution = false),
+        classOf[RemoveScreenshotsTask])
     val removeScreenshotsBeforeExecution = tasks
-      .register(RemoveScreenshotsTask.name(flavor, buildType, beforeExecution = true),
-                classOf[RemoveScreenshotsTask])
+      .register(
+        RemoveScreenshotsTask.name(flavor, buildType, beforeExecution = true),
+        classOf[RemoveScreenshotsTask])
 
     removeScreenshotsAfterExecution.configure { task =>
       task.setDescription(RemoveScreenshotsTask.description(flavor, buildType))
@@ -187,7 +189,9 @@ class ShotPlugin extends Plugin[Project] {
       downloadScreenshots.configure { task =>
         task.mustRunAfter(instrumentationTask)
       }
-      tasks.getByName(instrumentationTask).dependsOn(removeScreenshotsBeforeExecution)
+      tasks
+        .getByName(instrumentationTask)
+        .dependsOn(removeScreenshotsBeforeExecution)
       removeScreenshotsAfterExecution.configure { task =>
         task.mustRunAfter(downloadScreenshots)
       }

--- a/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
+++ b/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
@@ -113,12 +113,14 @@ class DownloadScreenshotsTask extends ShotTask {
 }
 
 object RemoveScreenshotsTask {
-  def name(flavor: String, buildType: BuildType) =
+  def name(flavor: String, buildType: BuildType, beforeExecution: Boolean) = {
+    val suffix = if (beforeExecution) "Before" else "After"
     if (flavor.isEmpty) {
-      s"${buildType.getName}RemoveScreenshots"
+      s"${buildType.getName}RemoveScreenshots${suffix}"
     } else {
-      s"${flavor}${buildType.getName.capitalize}RemoveScreenshots"
+      s"${flavor}${buildType.getName.capitalize}RemoveScreenshots${suffix}"
     }
+  }
 
   def description(flavor: String, buildType: BuildType) =
     s"Removes the screenshots recorded during the tests execution from the Android device where the tests were executed for the build ${flavor.capitalize}${buildType.getName.capitalize}"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Fixes #199

### :tophat: What is the goal?

Avoid a bug found after running a suite of tests two times where the first execution fails.

### How is it being implemented?

The ``Downloads`` folder is only configured to write content. We can't override it or rename it. If you think we can delete content, it's not your day. This was causing the second build after a failed execution to crash. This is the best fix I've found, cleaning the folder before and after running our tests.

### How can it be tested?

There is no way I can write automated tests for this.