### PR TITLE
Migrate consumer modules to AndroidX

### DIFF
--- a/shot-consumer-flavors/app/build.gradle
+++ b/shot-consumer-flavors/app/build.gradle
@@ -66,8 +66,8 @@ configurations {
 dependencies {
     ktlint "com.github.shyiko:ktlint:0.29.0"
 
-    implementation "com.android.support:appcompat-v7:28.0.0"
-    implementation "com.android.support:design:28.0.0"
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
 
     implementation "com.github.salomonbrys.kodein:kodein:4.1.0"
     implementation "com.github.salomonbrys.kodein:kodein-core:4.1.0"
@@ -76,8 +76,8 @@ dependencies {
     implementation "com.squareup.picasso:picasso:2.5.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1"
-    implementation "android.arch.lifecycle:extensions:1.1.1"
-    annotationProcessor "android.arch.lifecycle:compiler:1.1.1"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.0.0'
 
     testImplementation "junit:junit:4.13"
 

--- a/shot-consumer-flavors/app/src/main/java/com/karumi/ui/presenter/SuperHeroDetailPresenter.kt
+++ b/shot-consumer-flavors/app/src/main/java/com/karumi/ui/presenter/SuperHeroDetailPresenter.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.presenter
 
-import android.arch.lifecycle.Lifecycle.Event.ON_RESUME
-import android.arch.lifecycle.LifecycleObserver
-import android.arch.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.karumi.common.async
 import com.karumi.common.weak
 import com.karumi.domain.model.SuperHero

--- a/shot-consumer-flavors/app/src/main/java/com/karumi/ui/presenter/SuperHeroesPresenter.kt
+++ b/shot-consumer-flavors/app/src/main/java/com/karumi/ui/presenter/SuperHeroesPresenter.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.presenter
 
-import android.arch.lifecycle.Lifecycle.Event.ON_RESUME
-import android.arch.lifecycle.LifecycleObserver
-import android.arch.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.karumi.common.async
 import com.karumi.common.weak
 import com.karumi.domain.model.SuperHero

--- a/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/BaseActivity.kt
+++ b/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/BaseActivity.kt
@@ -1,9 +1,9 @@
 package com.karumi.ui.view
 
-import android.arch.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleObserver
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.widget.Toolbar
+import androidx.appcompat.widget.Toolbar
 import com.github.salomonbrys.kodein.Kodein.Module
 import com.github.salomonbrys.kodein.android.KodeinAppCompatActivity
 import com.karumi.asApp

--- a/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/MainActivity.kt
+++ b/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/MainActivity.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.view
 
 import android.os.Bundle
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.Toolbar
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.appcompat.widget.Toolbar
 import android.view.View
 import com.github.salomonbrys.kodein.Kodein.Module
 import com.github.salomonbrys.kodein.bind

--- a/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/SuperHeroDetailActivity.kt
+++ b/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/SuperHeroDetailActivity.kt
@@ -2,7 +2,7 @@ package com.karumi.ui.view
 
 import android.app.Activity
 import android.content.Intent
-import android.support.v7.widget.Toolbar
+import androidx.appcompat.widget.Toolbar
 import android.view.View
 import com.github.salomonbrys.kodein.Kodein.Module
 import com.github.salomonbrys.kodein.bind

--- a/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/adapter/SuperHeroViewHolder.kt
+++ b/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/adapter/SuperHeroViewHolder.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view.adapter
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView

--- a/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/adapter/SuperHeroesAdapter.kt
+++ b/shot-consumer-flavors/app/src/main/java/com/karumi/ui/view/adapter/SuperHeroesAdapter.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view.adapter
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.karumi.R

--- a/shot-consumer-flavors/app/src/main/res/layout/main_activity.xml
+++ b/shot-consumer-flavors/app/src/main/res/layout/main_activity.xml
@@ -23,7 +23,7 @@
     tools:context="com.karumi.ui.view.MainActivity"
     >
 
-  <android.support.v7.widget.Toolbar
+  <androidx.appcompat.widget.Toolbar
       android:id="@+id/toolbar"
       android:layout_width="match_parent"
       android:layout_height="?attr/actionBarSize"
@@ -31,7 +31,7 @@
       android:theme="@style/AppTheme.AppBarOverlay"
       app:popupTheme="@style/AppTheme.PopupOverlay"
       />
-  <android.support.v7.widget.RecyclerView
+  <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/recycler_view"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
@@ -40,7 +40,7 @@
       tools:showIn="@layout/main_activity"
       />
 
-  <android.support.v4.widget.ContentLoadingProgressBar
+  <androidx.core.widget.ContentLoadingProgressBar
       android:id="@+id/progress_bar"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"

--- a/shot-consumer-flavors/app/src/main/res/layout/super_hero_detail_activity.xml
+++ b/shot-consumer-flavors/app/src/main/res/layout/super_hero_detail_activity.xml
@@ -38,7 +38,7 @@
         android:orientation="vertical"
         >
 
-      <android.support.v7.widget.Toolbar
+      <androidx.appcompat.widget.Toolbar
           android:id="@+id/toolbar"
           android:layout_width="match_parent"
           android:layout_height="?attr/actionBarSize"
@@ -93,7 +93,7 @@
     </LinearLayout>
 
 
-    <android.support.v4.widget.ContentLoadingProgressBar
+    <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/shot-consumer-flavors/gradle.properties
+++ b/shot-consumer-flavors/gradle.properties
@@ -16,3 +16,4 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.useAndroidX=true
+android.enableJetifier=true

--- a/shot-consumer/app/build.gradle
+++ b/shot-consumer/app/build.gradle
@@ -52,8 +52,8 @@ configurations {
 dependencies {
     ktlint "com.github.shyiko:ktlint:0.29.0"
 
-    implementation "com.android.support:appcompat-v7:28.0.0"
-    implementation "com.android.support:design:28.0.0"
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
 
     implementation "com.github.salomonbrys.kodein:kodein:4.1.0"
     implementation "com.github.salomonbrys.kodein:kodein-core:4.1.0"
@@ -62,8 +62,8 @@ dependencies {
     implementation "com.squareup.picasso:picasso:2.5.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9"
-    implementation "android.arch.lifecycle:extensions:1.1.1"
-    annotationProcessor "android.arch.lifecycle:compiler:1.1.1"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.0.0'
 
     testImplementation "junit:junit:4.12"
 

--- a/shot-consumer/app/src/androidTest/java/com/karumi/ui/view/SuperHeroViewHolderTest.kt
+++ b/shot-consumer/app/src/androidTest/java/com/karumi/ui/view/SuperHeroViewHolderTest.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.karumi.R

--- a/shot-consumer/app/src/main/java/com/karumi/ui/presenter/CursorPresenter.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/presenter/CursorPresenter.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.presenter
 
-import android.arch.lifecycle.Lifecycle
-import android.arch.lifecycle.LifecycleObserver
-import android.arch.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.karumi.common.weak
 
 class CursorPresenter(view: View) : LifecycleObserver {

--- a/shot-consumer/app/src/main/java/com/karumi/ui/presenter/ScrollPresenter.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/presenter/ScrollPresenter.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.presenter
 
-import android.arch.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleObserver
 
 class ScrollPresenter : LifecycleObserver {
 

--- a/shot-consumer/app/src/main/java/com/karumi/ui/presenter/SimplePresenter.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/presenter/SimplePresenter.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.presenter
 
-import android.arch.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleObserver
 
 class SimplePresenter : LifecycleObserver {
 

--- a/shot-consumer/app/src/main/java/com/karumi/ui/presenter/SuperHeroDetailPresenter.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/presenter/SuperHeroDetailPresenter.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.presenter
 
-import android.arch.lifecycle.Lifecycle.Event.ON_RESUME
-import android.arch.lifecycle.LifecycleObserver
-import android.arch.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.karumi.common.async
 import com.karumi.common.weak
 import com.karumi.domain.model.SuperHero

--- a/shot-consumer/app/src/main/java/com/karumi/ui/presenter/SuperHeroesPresenter.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/presenter/SuperHeroesPresenter.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.presenter
 
-import android.arch.lifecycle.Lifecycle.Event.ON_RESUME
-import android.arch.lifecycle.LifecycleObserver
-import android.arch.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.karumi.common.async
 import com.karumi.common.weak
 import com.karumi.domain.model.SuperHero

--- a/shot-consumer/app/src/main/java/com/karumi/ui/view/BaseActivity.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/view/BaseActivity.kt
@@ -1,9 +1,9 @@
 package com.karumi.ui.view
 
-import android.arch.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleObserver
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.widget.Toolbar
+import androidx.appcompat.widget.Toolbar
 import com.github.salomonbrys.kodein.Kodein.Module
 import com.github.salomonbrys.kodein.android.KodeinAppCompatActivity
 import com.karumi.asApp

--- a/shot-consumer/app/src/main/java/com/karumi/ui/view/CursorActivity.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/view/CursorActivity.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view
 
-import android.support.v7.widget.Toolbar
+import androidx.appcompat.widget.Toolbar
 import android.view.View
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.bind

--- a/shot-consumer/app/src/main/java/com/karumi/ui/view/HideViewsActivity.java
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/view/HideViewsActivity.java
@@ -1,8 +1,8 @@
 package com.karumi.ui.view;
 
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.karumi.R;
 

--- a/shot-consumer/app/src/main/java/com/karumi/ui/view/MainActivity.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/view/MainActivity.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.view
 
 import android.os.Bundle
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.Toolbar
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.appcompat.widget.Toolbar
 import android.view.View
 import com.github.salomonbrys.kodein.Kodein.Module
 import com.github.salomonbrys.kodein.bind

--- a/shot-consumer/app/src/main/java/com/karumi/ui/view/ScrollActivity.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/view/ScrollActivity.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view
 
-import android.support.v7.widget.Toolbar
+import androidx.appcompat.widget.Toolbar
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.bind
 import com.github.salomonbrys.kodein.instance

--- a/shot-consumer/app/src/main/java/com/karumi/ui/view/SimpleActivity.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/view/SimpleActivity.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view
 
-import android.support.v7.widget.Toolbar
+import androidx.appcompat.widget.Toolbar
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.bind
 import com.github.salomonbrys.kodein.instance

--- a/shot-consumer/app/src/main/java/com/karumi/ui/view/SuperHeroDetailActivity.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/view/SuperHeroDetailActivity.kt
@@ -2,7 +2,7 @@ package com.karumi.ui.view
 
 import android.app.Activity
 import android.content.Intent
-import android.support.v7.widget.Toolbar
+import androidx.appcompat.widget.Toolbar
 import android.view.View
 import com.github.salomonbrys.kodein.Kodein.Module
 import com.github.salomonbrys.kodein.bind

--- a/shot-consumer/app/src/main/java/com/karumi/ui/view/adapter/SuperHeroViewHolder.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/view/adapter/SuperHeroViewHolder.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view.adapter
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView

--- a/shot-consumer/app/src/main/java/com/karumi/ui/view/adapter/SuperHeroesAdapter.kt
+++ b/shot-consumer/app/src/main/java/com/karumi/ui/view/adapter/SuperHeroesAdapter.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view.adapter
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.karumi.R

--- a/shot-consumer/app/src/main/res/layout/cursor_activity.xml
+++ b/shot-consumer/app/src/main/res/layout/cursor_activity.xml
@@ -8,7 +8,7 @@
     android:gravity="bottom"
     tools:context="com.karumi.ui.view.CursorActivity">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/shot-consumer/app/src/main/res/layout/main_activity.xml
+++ b/shot-consumer/app/src/main/res/layout/main_activity.xml
@@ -23,7 +23,7 @@
     tools:context="com.karumi.ui.view.MainActivity"
     >
 
-  <android.support.v7.widget.Toolbar
+  <androidx.appcompat.widget.Toolbar
       android:id="@+id/toolbar"
       android:layout_width="match_parent"
       android:layout_height="?attr/actionBarSize"
@@ -31,7 +31,7 @@
       android:theme="@style/AppTheme.AppBarOverlay"
       app:popupTheme="@style/AppTheme.PopupOverlay"
       />
-  <android.support.v7.widget.RecyclerView
+  <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/recycler_view"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
@@ -40,7 +40,7 @@
       tools:showIn="@layout/main_activity"
       />
 
-  <android.support.v4.widget.ContentLoadingProgressBar
+  <androidx.core.widget.ContentLoadingProgressBar
       android:id="@+id/progress_bar"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"

--- a/shot-consumer/app/src/main/res/layout/scroll_activity.xml
+++ b/shot-consumer/app/src/main/res/layout/scroll_activity.xml
@@ -7,7 +7,7 @@
     android:orientation="vertical"
     tools:context="com.karumi.ui.view.ScrollActivity">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/shot-consumer/app/src/main/res/layout/simple_activity.xml
+++ b/shot-consumer/app/src/main/res/layout/simple_activity.xml
@@ -7,7 +7,7 @@
     android:orientation="vertical"
     tools:context="com.karumi.ui.view.SimpleActivity">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"

--- a/shot-consumer/app/src/main/res/layout/super_hero_detail_activity.xml
+++ b/shot-consumer/app/src/main/res/layout/super_hero_detail_activity.xml
@@ -38,7 +38,7 @@
         android:orientation="vertical"
         >
 
-      <android.support.v7.widget.Toolbar
+      <androidx.appcompat.widget.Toolbar
           android:id="@+id/toolbar"
           android:layout_width="match_parent"
           android:layout_height="?attr/actionBarSize"
@@ -93,7 +93,7 @@
     </LinearLayout>
 
 
-    <android.support.v4.widget.ContentLoadingProgressBar
+    <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/shot-consumer/app2/build.gradle
+++ b/shot-consumer/app2/build.gradle
@@ -52,8 +52,8 @@ configurations {
 dependencies {
     ktlint "com.github.shyiko:ktlint:0.29.0"
 
-    implementation "com.android.support:appcompat-v7:28.0.0"
-    implementation "com.android.support:design:28.0.0"
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
 
     implementation "com.github.salomonbrys.kodein:kodein:4.1.0"
     implementation "com.github.salomonbrys.kodein:kodein-core:4.1.0"
@@ -62,8 +62,8 @@ dependencies {
     implementation "com.squareup.picasso:picasso:2.5.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1"
-    implementation "android.arch.lifecycle:extensions:1.1.1"
-    annotationProcessor "android.arch.lifecycle:compiler:1.1.1"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.0.0'
 
     testImplementation "junit:junit:4.13"
 

--- a/shot-consumer/app2/src/main/java/com/karumi/ui/presenter/SuperHeroDetailPresenter.kt
+++ b/shot-consumer/app2/src/main/java/com/karumi/ui/presenter/SuperHeroDetailPresenter.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.presenter
 
-import android.arch.lifecycle.Lifecycle.Event.ON_RESUME
-import android.arch.lifecycle.LifecycleObserver
-import android.arch.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.karumi.common.async
 import com.karumi.common.weak
 import com.karumi.domain.model.SuperHero

--- a/shot-consumer/app2/src/main/java/com/karumi/ui/presenter/SuperHeroesPresenter.kt
+++ b/shot-consumer/app2/src/main/java/com/karumi/ui/presenter/SuperHeroesPresenter.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.presenter
 
-import android.arch.lifecycle.Lifecycle.Event.ON_RESUME
-import android.arch.lifecycle.LifecycleObserver
-import android.arch.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import com.karumi.common.async
 import com.karumi.common.weak
 import com.karumi.domain.model.SuperHero

--- a/shot-consumer/app2/src/main/java/com/karumi/ui/view/BaseActivity.kt
+++ b/shot-consumer/app2/src/main/java/com/karumi/ui/view/BaseActivity.kt
@@ -1,9 +1,9 @@
 package com.karumi.ui.view
 
-import android.arch.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleObserver
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.widget.Toolbar
+import androidx.appcompat.widget.Toolbar
 import com.github.salomonbrys.kodein.Kodein.Module
 import com.github.salomonbrys.kodein.android.KodeinAppCompatActivity
 import com.karumi.asApp

--- a/shot-consumer/app2/src/main/java/com/karumi/ui/view/MainActivity.kt
+++ b/shot-consumer/app2/src/main/java/com/karumi/ui/view/MainActivity.kt
@@ -1,8 +1,8 @@
 package com.karumi.ui.view
 
 import android.os.Bundle
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.Toolbar
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.appcompat.widget.Toolbar
 import android.view.View
 import com.github.salomonbrys.kodein.Kodein.Module
 import com.github.salomonbrys.kodein.bind

--- a/shot-consumer/app2/src/main/java/com/karumi/ui/view/SuperHeroDetailActivity.kt
+++ b/shot-consumer/app2/src/main/java/com/karumi/ui/view/SuperHeroDetailActivity.kt
@@ -2,7 +2,7 @@ package com.karumi.ui.view
 
 import android.app.Activity
 import android.content.Intent
-import android.support.v7.widget.Toolbar
+import androidx.appcompat.widget.Toolbar
 import android.view.View
 import com.github.salomonbrys.kodein.Kodein.Module
 import com.github.salomonbrys.kodein.bind

--- a/shot-consumer/app2/src/main/java/com/karumi/ui/view/adapter/SuperHeroViewHolder.kt
+++ b/shot-consumer/app2/src/main/java/com/karumi/ui/view/adapter/SuperHeroViewHolder.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view.adapter
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView

--- a/shot-consumer/app2/src/main/java/com/karumi/ui/view/adapter/SuperHeroesAdapter.kt
+++ b/shot-consumer/app2/src/main/java/com/karumi/ui/view/adapter/SuperHeroesAdapter.kt
@@ -1,6 +1,6 @@
 package com.karumi.ui.view.adapter
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.karumi.R

--- a/shot-consumer/app2/src/main/res/layout/main_activity.xml
+++ b/shot-consumer/app2/src/main/res/layout/main_activity.xml
@@ -23,7 +23,7 @@
     tools:context="com.karumi.ui.view.MainActivity"
     >
 
-  <android.support.v7.widget.Toolbar
+  <androidx.appcompat.widget.Toolbar
       android:id="@+id/toolbar"
       android:layout_width="match_parent"
       android:layout_height="?attr/actionBarSize"
@@ -31,7 +31,7 @@
       android:theme="@style/AppTheme.AppBarOverlay"
       app:popupTheme="@style/AppTheme.PopupOverlay"
       />
-  <android.support.v7.widget.RecyclerView
+  <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/recycler_view"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
@@ -40,7 +40,7 @@
       tools:showIn="@layout/main_activity"
       />
 
-  <android.support.v4.widget.ContentLoadingProgressBar
+  <androidx.core.widget.ContentLoadingProgressBar
       android:id="@+id/progress_bar"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"

--- a/shot-consumer/app2/src/main/res/layout/super_hero_detail_activity.xml
+++ b/shot-consumer/app2/src/main/res/layout/super_hero_detail_activity.xml
@@ -38,7 +38,7 @@
         android:orientation="vertical"
         >
 
-      <android.support.v7.widget.Toolbar
+      <androidx.appcompat.widget.Toolbar
           android:id="@+id/toolbar"
           android:layout_width="match_parent"
           android:layout_height="?attr/actionBarSize"
@@ -93,7 +93,7 @@
     </LinearLayout>
 
 
-    <android.support.v4.widget.ContentLoadingProgressBar
+    <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/shot-consumer/gradle.properties
+++ b/shot-consumer/gradle.properties
@@ -16,3 +16,4 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
### :tophat: What is the goal?

I actually wanted to contribute by writing tests for `compareScreenshot(Fragment)`. However, the method accepts an AndroidX Fragment while consumers are mostly Support-based. 

Mixing these 2 approaches caused various build issues for me, which I tried to fix whack-a-mole-style. Then I figured it'd be easier and cleaner to just migrate the whole thing to AndroidX.

### How is it being implemented?

[Android Developers: Migrating to AndroidX](https://developer.android.com/jetpack/androidx/migrate)

Modules in consumer projects (i.e. `shot-consumer`, `shot-consumer-flavors`) depended on old Support library dependencies, i.e `android.support`.

I used Android Studio's built-in migration with minor cleanup in places where it left some redundant FQCN.

It seems that it worked fine (tests passed locally), but let's see if CI agrees.

The migration didn't use dependencies' latest versions. I decided to ignore that at this stage to minimize PR changes.

### How can it be tested?

Run screenshot tests in consumer projects:
```sh
./gradlew executeScreenshotTests
```