### PR TITLE
Update scalafmt to 1.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         classpath "gradle.plugin.com.github.maiflai:gradle-scalatest:0.25"
-        classpath "cz.alenkacz:gradle-scalafmt:1.3.5"
+        classpath "cz.alenkacz:gradle-scalafmt:1.14.0"
         classpath "com.android.tools.build:gradle:3.4.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:9.4.1"

--- a/core/src/main/scala/com/karumi/shot/Shot.scala
+++ b/core/src/main/scala/com/karumi/shot/Shot.scala
@@ -47,63 +47,43 @@ class Shot(adb: Adb,
                         flavor: String,
                         buildType: String): Unit = {
     console.show("💾  Saving screenshots.")
-    moveComposeScreenshotsToRegularScreenshotsFolder(projectFolder,
-                                                     flavor,
-                                                     buildType)
+    moveComposeScreenshotsToRegularScreenshotsFolder(projectFolder, flavor, buildType)
     val composeScreenshotSuite: ScreenshotsSuite =
-      recordComposeScreenshots(buildFolder,
-                               projectFolder,
-                               projectName,
-                               flavor,
-                               buildType)
+      recordComposeScreenshots(buildFolder, projectFolder, projectName, flavor, buildType)
     val regularScreenshotSuite: ScreenshotsSuite =
-      recordRegularScreenshots(buildFolder,
-                               projectFolder,
-                               projectName,
-                               flavor,
-                               buildType)
+      recordRegularScreenshots(buildFolder, projectFolder, projectName, flavor, buildType)
     val screenshots = regularScreenshotSuite ++ composeScreenshotSuite
     console.show(
       "😃  Screenshots recorded and saved at: " + projectFolder + Config
         .screenshotsFolderName(flavor, buildType))
-    reporter.generateRecordReport(appId,
-                                  screenshots,
-                                  buildFolder,
-                                  flavor,
-                                  buildType)
+    reporter.generateRecordReport(appId, screenshots, buildFolder, flavor, buildType)
     console.show(
       "🤓  You can review the execution report here: " + buildFolder + Config
         .recordingReportFolder(flavor, buildType) + "/index.html")
     removeProjectTemporalScreenshotsFolder(projectFolder, flavor, buildType)
   }
 
-  def verifyScreenshots(
-      appId: AppId,
-      buildFolder: Folder,
-      projectFolder: Folder,
-      flavor: String,
-      buildType: String,
-      projectName: String,
-      shouldPrintBase64Error: Boolean,
-      tolerance: Double,
-      showOnlyFailingTestsInReports: Boolean): ScreenshotsComparisionResult = {
+  def verifyScreenshots(appId: AppId,
+                        buildFolder: Folder,
+                        projectFolder: Folder,
+                        flavor: String,
+                        buildType: String,
+                        projectName: String,
+                        shouldPrintBase64Error: Boolean,
+                        tolerance: Double,
+                        showOnlyFailingTestsInReports: Boolean): ScreenshotsComparisionResult = {
     console.show("🔎  Comparing screenshots with previous ones.")
-    moveComposeScreenshotsToRegularScreenshotsFolder(projectFolder,
-                                                     flavor,
-                                                     buildType)
+    moveComposeScreenshotsToRegularScreenshotsFolder(projectFolder, flavor, buildType)
     val regularScreenshots =
       readScreenshotsMetadata(projectFolder, flavor, buildType, projectName)
-    val composeScreenshots = readComposeScreenshotsMetadata(projectFolder,
-                                                            flavor,
-                                                            buildType,
-                                                            projectName)
+    val composeScreenshots =
+      readComposeScreenshotsMetadata(projectFolder, flavor, buildType, projectName)
     val screenshots = regularScreenshots ++ composeScreenshots
     val newScreenshotsVerificationReportFolder = buildFolder + Config
       .verificationReportFolder(flavor, buildType) + "/images/"
-    screenshotsSaver.saveTemporalScreenshots(
-      screenshots,
-      projectName,
-      newScreenshotsVerificationReportFolder)
+    screenshotsSaver.saveTemporalScreenshots(screenshots,
+                                             projectName,
+                                             newScreenshotsVerificationReportFolder)
     val comparison = screenshotsComparator.compare(screenshots, tolerance)
     val updatedComparison = screenshotsDiffGenerator.generateDiffs(
       comparison,
@@ -113,9 +93,8 @@ class Shot(adb: Adb,
     if (showOnlyFailingTestsInReports) {
       val verificationReferenceImagesFolder = buildFolder + Config
         .verificationReportFolder(flavor, buildType) + "/images/"
-      screenshotsSaver.removeNonFailingReferenceImages(
-        verificationReferenceImagesFolder,
-        comparison)
+      screenshotsSaver.removeNonFailingReferenceImages(verificationReferenceImagesFolder,
+                                                       comparison)
       screenshotsSaver.copyOnlyFailingRecordedScreenshotsToTheReportFolder(
         buildFolder + Config
           .verificationReportFolder(flavor, buildType) + "/images/recorded/",
@@ -130,13 +109,10 @@ class Shot(adb: Adb,
     }
 
     if (updatedComparison.hasErrors) {
-      consoleReporter.showErrors(updatedComparison,
-                                 newScreenshotsVerificationReportFolder)
+      consoleReporter.showErrors(updatedComparison, newScreenshotsVerificationReportFolder)
 
-      console.showError(
-        "🤔 Do you a need a hand with your automated tests or your Android app?")
-      console.showError(
-        "   We'll be happy to help! Send us an email to hello@karumi.com\n")
+      console.showError("🤔 Do you a need a hand with your automated tests or your Android app?")
+      console.showError("   We'll be happy to help! Send us an email to hello@karumi.com\n")
     } else {
       console.showSuccess("✅  Yeah!!! Your tests are passing.")
     }
@@ -156,19 +132,15 @@ class Shot(adb: Adb,
   def removeScreenshots(appId: AppId): Unit =
     clearScreenshots(appId)
 
-  private def moveComposeScreenshotsToRegularScreenshotsFolder(
-      projectFolder: Folder,
-      flavor: String,
-      buildType: String): Unit = {
-    val composeFolder = projectFolder + Config.pulledComposeScreenshotsFolder(
-      flavor,
-      buildType)
+  private def moveComposeScreenshotsToRegularScreenshotsFolder(projectFolder: Folder,
+                                                               flavor: String,
+                                                               buildType: String): Unit = {
+    val composeFolder = projectFolder + Config.pulledComposeScreenshotsFolder(flavor, buildType)
     files.listFilesInFolder(composeFolder).forEach { file: File =>
       val rawFilePath = file.getAbsolutePath
       val newFilePath =
-        rawFilePath.replace(
-          Config.pulledComposeScreenshotsFolder(flavor, buildType),
-          Config.pulledScreenshotsFolder(flavor, buildType))
+        rawFilePath.replace(Config.pulledComposeScreenshotsFolder(flavor, buildType),
+                            Config.pulledScreenshotsFolder(flavor, buildType))
       files.rename(rawFilePath, newFilePath)
     }
   }
@@ -180,10 +152,7 @@ class Shot(adb: Adb,
                                        buildType: String) = {
     val screenshots =
       readScreenshotsMetadata(projectFolder, flavor, buildType, projectName)
-    screenshotsSaver.saveRecordedScreenshots(projectFolder,
-                                             flavor,
-                                             buildType,
-                                             screenshots)
+    screenshotsSaver.saveRecordedScreenshots(projectFolder, flavor, buildType, screenshots)
     screenshotsSaver.copyRecordedScreenshotsToTheReportFolder(
       projectFolder,
       flavor,
@@ -198,14 +167,8 @@ class Shot(adb: Adb,
                                        projectName: String,
                                        flavor: String,
                                        buildType: String) = {
-    val screenshots = readComposeScreenshotsMetadata(projectFolder,
-                                                     flavor,
-                                                     buildType,
-                                                     projectName)
-    screenshotsSaver.saveRecordedScreenshots(projectFolder,
-                                             flavor,
-                                             buildType,
-                                             screenshots)
+    val screenshots = readComposeScreenshotsMetadata(projectFolder, flavor, buildType, projectName)
+    screenshotsSaver.saveRecordedScreenshots(projectFolder, flavor, buildType, screenshots)
     screenshotsSaver.copyRecordedScreenshotsToTheReportFolder(
       projectFolder,
       flavor,
@@ -222,11 +185,11 @@ class Shot(adb: Adb,
   private def forEachDevice[T](f: String => T): Unit = devices().foreach(f)
 
   private def devices(): List[String] = {
-    val allDevices = adb.devices
+    val allDevices      = adb.devices
     val specifiedDevice = envVars.androidSerial
     specifiedDevice match {
       case Some(device) if allDevices.contains(device) => List(device)
-      case _ => allDevices
+      case _                                           => allDevices
     }
   }
 
@@ -240,43 +203,31 @@ class Shot(adb: Adb,
                               flavor: String,
                               buildType: String): Unit =
     forEachDevice { device =>
-      val screenshotsFolder = projectFolder + Config.screenshotsFolderName(
-        flavor,
-        buildType)
+      val screenshotsFolder = projectFolder + Config.screenshotsFolderName(flavor, buildType)
       createScreenshotsFolderIfDoesNotExist(screenshotsFolder)
       adb.pullScreenshots(device, screenshotsFolder, appId)
 
-      extractPicturesFromBundle(
-        projectFolder + Config.pulledScreenshotsFolder(flavor, buildType))
-      renameMetadataFile(projectFolder,
-                         device,
-                         Config.metadataFileName(flavor, buildType))
-      renameMetadataFile(projectFolder,
-                         device,
-                         Config.composeMetadataFileName(flavor, buildType))
+      extractPicturesFromBundle(projectFolder + Config.pulledScreenshotsFolder(flavor, buildType))
+      renameMetadataFile(projectFolder, device, Config.metadataFileName(flavor, buildType))
+      renameMetadataFile(projectFolder, device, Config.composeMetadataFileName(flavor, buildType))
     }
 
   private def renameMetadataFile(projectFolder: Folder,
                                  device: String,
                                  metadataFileName: String): Unit = {
-    val metadataFilePath = projectFolder + metadataFileName
+    val metadataFilePath    = projectFolder + metadataFileName
     val newMetadataFilePath = metadataFilePath + "_" + device
     files.rename(metadataFilePath, newMetadataFilePath)
   }
 
-  private def readScreenshotsMetadata(
-      projectFolder: Folder,
-      flavor: String,
-      buildType: String,
-      projectName: String): ScreenshotsSuite = {
-    val screenshotsFolder = projectFolder + Config.pulledScreenshotsFolder(
-      flavor,
-      buildType)
+  private def readScreenshotsMetadata(projectFolder: Folder,
+                                      flavor: String,
+                                      buildType: String,
+                                      projectName: String): ScreenshotsSuite = {
+    val screenshotsFolder       = projectFolder + Config.pulledScreenshotsFolder(flavor, buildType)
     val filesInScreenshotFolder = new java.io.File(screenshotsFolder).listFiles
-    val metadataFiles = filesInScreenshotFolder.filter(
-      file =>
-        file.getAbsolutePath.contains(
-          Config.metadataFileName(flavor, buildType)))
+    val metadataFiles = filesInScreenshotFolder.filter(file =>
+      file.getAbsolutePath.contains(Config.metadataFileName(flavor, buildType)))
     val screenshotSuite = metadataFiles.flatMap { metadataFilePath =>
       val metadataFileContent =
         files.read(metadataFilePath.getAbsolutePath)
@@ -295,18 +246,14 @@ class Shot(adb: Adb,
     }.toList
   }
 
-  private def readComposeScreenshotsMetadata(
-      projectFolder: Folder,
-      flavor: String,
-      buildType: String,
-      projectName: String): ScreenshotsSuite = {
-    val screenshotsFolder = projectFolder + Config.pulledScreenshotsFolder(
-      flavor,
-      buildType)
+  private def readComposeScreenshotsMetadata(projectFolder: Folder,
+                                             flavor: String,
+                                             buildType: String,
+                                             projectName: String): ScreenshotsSuite = {
+    val screenshotsFolder       = projectFolder + Config.pulledScreenshotsFolder(flavor, buildType)
     val filesInScreenshotFolder = new java.io.File(screenshotsFolder).listFiles
     val metadataFiles =
-      filesInScreenshotFolder.filter(file =>
-        file.getAbsolutePath.contains("metadata.json"))
+      filesInScreenshotFolder.filter(file => file.getAbsolutePath.contains("metadata.json"))
     val screenshotSuite = metadataFiles.flatMap { metadataFilePath =>
       val metadataFileContent =
         files.read(metadataFilePath.getAbsolutePath)
@@ -318,18 +265,15 @@ class Shot(adb: Adb,
       )
     }
     screenshotSuite.par.map { screenshot =>
-      val dimension = screenshotsSaver.getScreenshotDimension(projectFolder,
-                                                              flavor,
-                                                              buildType,
-                                                              screenshot)
+      val dimension =
+        screenshotsSaver.getScreenshotDimension(projectFolder, flavor, buildType, screenshot)
       screenshot.copy(screenshotDimension = dimension)
     }.toList
   }
 
-  private def removeProjectTemporalScreenshotsFolder(
-      projectFolder: Folder,
-      flavor: String,
-      buildType: String): Unit = {
+  private def removeProjectTemporalScreenshotsFolder(projectFolder: Folder,
+                                                     flavor: String,
+                                                     buildType: String): Unit = {
     val projectTemporalScreenshots = new File(
       projectFolder + Config.pulledScreenshotsFolder(flavor, buildType))
 

--- a/core/src/main/scala/com/karumi/shot/android/Adb.scala
+++ b/core/src/main/scala/com/karumi/shot/android/Adb.scala
@@ -18,9 +18,7 @@ class Adb {
   private final val CR_ASCII_DECIMAL = 13
   private val logger = ProcessLogger(
     outputMessage => println("Shot ADB output: " + outputMessage),
-    errorMessage =>
-      println(
-        Console.YELLOW + "Shot ADB warning: " + errorMessage + Console.RESET)
+    errorMessage => println(Console.YELLOW + "Shot ADB warning: " + errorMessage + Console.RESET)
   )
 
   def devices: List[String] = {
@@ -34,9 +32,7 @@ class Adb {
       .filter(device => !isCarriageReturnASCII(device))
   }
 
-  def pullScreenshots(device: String,
-                      screenshotsFolder: Folder,
-                      appId: AppId): Unit = {
+  def pullScreenshots(device: String, screenshotsFolder: Folder, appId: AppId): Unit = {
     pullFolder("screenshots-default", device, screenshotsFolder, appId)
     pullFolder("screenshots-compose-default", device, screenshotsFolder, appId)
   }
@@ -52,8 +48,7 @@ class Adb {
                          appId: AppId) = {
     val folderToPull = s"${baseStoragePath}/screenshots/$appId/$folderName/"
     try {
-      executeAdbCommandWithResult(
-        s"-s $device pull $folderToPull $screenshotsFolder")
+      executeAdbCommandWithResult(s"-s $device pull $folderToPull $screenshotsFolder")
     } catch {
       case _: Throwable =>
         println(
@@ -61,11 +56,8 @@ class Adb {
     }
   }
 
-  private def clearScreenshotsFromFolder(device: String,
-                                         appId: AppId,
-                                         folder: AppId) =
-    executeAdbCommand(
-      s"-s $device shell rm -r $baseStoragePath/screenshots/$appId/$folder/")
+  private def clearScreenshotsFromFolder(device: String, appId: AppId, folder: AppId) =
+    executeAdbCommand(s"-s $device shell rm -r $baseStoragePath/screenshots/$appId/$folder/")
 
   private def executeAdbCommand(command: String): Int =
     s"${Adb.adbBinaryPath} $command" ! logger

--- a/core/src/main/scala/com/karumi/shot/base64/Base64Encoder.scala
+++ b/core/src/main/scala/com/karumi/shot/base64/Base64Encoder.scala
@@ -12,7 +12,7 @@ class Base64Encoder {
     var outputStream: ByteArrayOutputStream = null
     try {
       val diffScreenshotFile = new File(filePath)
-      val bufferedImage = ImageIO.read(diffScreenshotFile)
+      val bufferedImage      = ImageIO.read(diffScreenshotFile)
       outputStream = new ByteArrayOutputStream()
       ImageIO.write(bufferedImage, "png", outputStream)
       val diffImageBase64Encoded =

--- a/core/src/main/scala/com/karumi/shot/domain/model.scala
+++ b/core/src/main/scala/com/karumi/shot/domain/model.scala
@@ -1,25 +1,21 @@
 package com.karumi.shot.domain
 
-import com.karumi.shot.domain.model.{
-  FilePath,
-  ScreenshotComparisionErrors,
-  ScreenshotsSuite
-}
+import com.karumi.shot.domain.model.{FilePath, ScreenshotComparisionErrors, ScreenshotsSuite}
 
 object model {
-  type ScreenshotsSuite = Seq[Screenshot]
-  type FilePath = String
-  type Folder = String
-  type AppId = String
+  type ScreenshotsSuite            = Seq[Screenshot]
+  type FilePath                    = String
+  type Folder                      = String
+  type AppId                       = String
   type ScreenshotComparisionErrors = Seq[ScreenshotComparisonError]
 }
 
 object Config {
-  val defaultTolerance: Double = 0.0
-  val shotConfiguration: String = "shotDependencies"
-  val androidDependencyMode: FilePath = "androidTestImplementation"
-  val androidDependencyGroup: String = "com.karumi"
-  val androidDependencyName: String = "shot-android"
+  val defaultTolerance: Double         = 0.0
+  val shotConfiguration: String        = "shotDependencies"
+  val androidDependencyMode: FilePath  = "androidTestImplementation"
+  val androidDependencyGroup: String   = "com.karumi"
+  val androidDependencyName: String    = "shot-android"
   val androidDependencyVersion: String = "5.10.4-SNAPSHOT"
   val androidDependency: FilePath =
     s"$androidDependencyGroup:$androidDependencyName:$androidDependencyVersion"
@@ -34,8 +30,7 @@ object Config {
   def pulledScreenshotsFolder(flavor: String, buildType: String): FilePath =
     screenshotsFolderName(flavor, buildType) + "screenshots-default/"
 
-  def pulledComposeScreenshotsFolder(flavor: String,
-                                     buildType: String): FilePath =
+  def pulledComposeScreenshotsFolder(flavor: String, buildType: String): FilePath =
     screenshotsFolderName(flavor, buildType) + "screenshots-compose-default/"
 
   def metadataFileName(flavor: String, buildType: String): FilePath =
@@ -44,11 +39,10 @@ object Config {
   def composeMetadataFileName(flavor: String, buildType: String): FilePath =
     pulledComposeScreenshotsFolder(flavor, buildType) + "metadata.json"
 
-  val androidPluginName: FilePath = "com.android.application"
+  val androidPluginName: FilePath           = "com.android.application"
   val screenshotsTemporalRootPath: FilePath = "/tmp/shot/screenshot/"
 
-  def defaultInstrumentationTestTask(flavor: String,
-                                     buildType: String): String =
+  def defaultInstrumentationTestTask(flavor: String, buildType: String): String =
     s"connected${flavor.capitalize}${buildType.capitalize}AndroidTest"
 
   def composerInstrumentationTestTask(flavor: String, buildType: String) =
@@ -79,9 +73,8 @@ case class Screenshot(name: String,
                       recordedPartsPaths: Seq[FilePath],
                       screenshotDimension: Dimension) {
   val fileName: String =
-    temporalScreenshotPath.substring(
-      temporalScreenshotPath.lastIndexOf("/") + 1,
-      temporalScreenshotPath.length)
+    temporalScreenshotPath.substring(temporalScreenshotPath.lastIndexOf("/") + 1,
+                                     temporalScreenshotPath.length)
 
   def getDiffScreenshotPath(basePath: String): String =
     s"${basePath}diff_$fileName"
@@ -97,17 +90,15 @@ case class Dimension(width: Int, height: Int) {
 sealed trait ScreenshotComparisonError {
   def errorScreenshot: Screenshot =
     this match {
-      case ScreenshotNotFound(screenshot) => screenshot
-      case DifferentScreenshots(screenshot, _) => screenshot
+      case ScreenshotNotFound(screenshot)             => screenshot
+      case DifferentScreenshots(screenshot, _)        => screenshot
       case DifferentImageDimensions(screenshot, _, _) => screenshot
     }
 }
 
-case class ScreenshotNotFound(screenshot: Screenshot)
-    extends ScreenshotComparisonError
+case class ScreenshotNotFound(screenshot: Screenshot) extends ScreenshotComparisonError
 
-case class DifferentScreenshots(screenshot: Screenshot,
-                                base64Diff: Option[String] = None)
+case class DifferentScreenshots(screenshot: Screenshot, base64Diff: Option[String] = None)
     extends ScreenshotComparisonError
 
 case class DifferentImageDimensions(screenshot: Screenshot,
@@ -117,7 +108,7 @@ case class DifferentImageDimensions(screenshot: Screenshot,
 
 case class ScreenshotsComparisionResult(errors: ScreenshotComparisionErrors,
                                         screenshots: ScreenshotsSuite) {
-  val hasErrors: Boolean = errors.nonEmpty
+  val hasErrors: Boolean                = errors.nonEmpty
   val errorScreenshots: Seq[Screenshot] = errors.map(_.errorScreenshot)
   val correctScreenshots: Seq[Screenshot] =
     screenshots.filterNot(errorScreenshots.contains(_))

--- a/core/src/main/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParser.scala
+++ b/core/src/main/scala/com/karumi/shot/json/ScreenshotsComposeSuiteJsonParser.scala
@@ -11,7 +11,7 @@ object ScreenshotsComposeSuiteJsonParser {
                        screenshotsFolder: Folder,
                        temporalScreenshotsFolder: Folder): ScreenshotsSuite = {
     implicit val formats: DefaultFormats.type = DefaultFormats
-    val composeSuite = parse(json).extract[ComposeScreenshotSuite]
+    val composeSuite                          = parse(json).extract[ComposeScreenshotSuite]
     composeSuite.screenshots.map { screenshot =>
       val name = screenshot.name
       Screenshot(
@@ -24,15 +24,12 @@ object ScreenshotsComposeSuiteJsonParser {
         viewHierarchy = "",
         absoluteFileNames = Seq(),
         relativeFileNames = Seq(),
-        recordedPartsPaths =
-          Seq(temporalScreenshotsFolder + "/" + name + ".png"),
+        recordedPartsPaths = Seq(temporalScreenshotsFolder + "/" + name + ".png"),
         screenshotDimension = Dimension(0, 0)
       )
     }
   }
 }
 
-case class ComposeScreenshot(name: String,
-                             testClassName: String,
-                             testName: String)
+case class ComposeScreenshot(name: String, testClassName: String, testName: String)
 case class ComposeScreenshotSuite(screenshots: List[ComposeScreenshot])

--- a/core/src/main/scala/com/karumi/shot/reports/ConsoleReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ConsoleReporter.scala
@@ -5,15 +5,12 @@ import com.karumi.shot.ui.Console
 
 class ConsoleReporter(console: Console) {
 
-  def showErrors(comparision: ScreenshotsComparisionResult,
-                 outputFolder: String): Unit = {
-    console.showError(
-      "❌  Hummmm...the following screenshot tests are broken:\n")
+  def showErrors(comparision: ScreenshotsComparisionResult, outputFolder: String): Unit = {
+    console.showError("❌  Hummmm...the following screenshot tests are broken:\n")
     comparision.errors.foreach { error =>
       error match {
         case ScreenshotNotFound(screenshot) =>
-          console.showError(
-            "   🔎  Recorded screenshot not found for test: " + screenshot.name)
+          console.showError("   🔎  Recorded screenshot not found for test: " + screenshot.name)
         case DifferentScreenshots(screenshot, base64Diff) =>
           console.showError(
             "   🤔  The application UI has been modified for test: " + screenshot.name)
@@ -22,9 +19,7 @@ class ConsoleReporter(console: Console) {
           console.showError(
             "            🆕  You can find the new recorded screenshot here: " + screenshot.temporalScreenshotPath)
           showBase64Diff(screenshot, base64Diff)
-        case DifferentImageDimensions(screenshot,
-                                      originalDimension,
-                                      newDimension) => {
+        case DifferentImageDimensions(screenshot, originalDimension, newDimension) => {
           console.showError(
             "   📱  The size of the screenshot taken has changed for test: " + screenshot.name)
           console.showError(
@@ -41,14 +36,13 @@ class ConsoleReporter(console: Console) {
     }
   }
 
-  private def showBase64Diff(screenshot: Screenshot,
-                             base64Diff: Option[String]) = base64Diff match {
-    case Some(diff) =>
-      console.showError(
-        "            🤖  The option printBase64 is enabled. In order to see the generated diff image for this failing test, run the following command in your terminal:")
-      console.showError(
-        s"            > echo '$diff' | base64 -D > ${screenshot.fileName}")
-    case _ =>
-  }
+  private def showBase64Diff(screenshot: Screenshot, base64Diff: Option[String]) =
+    base64Diff match {
+      case Some(diff) =>
+        console.showError(
+          "            🤖  The option printBase64 is enabled. In order to see the generated diff image for this failing test, run the following command in your terminal:")
+        console.showError(s"            > echo '$diff' | base64 -D > ${screenshot.fileName}")
+      case _ =>
+    }
 
 }

--- a/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
@@ -6,12 +6,7 @@ import java.util
 import scala.collection.JavaConverters._
 import org.apache.commons.io.FileUtils
 import com.karumi.shot.domain._
-import com.karumi.shot.domain.model.{
-  AppId,
-  Folder,
-  ScreenshotComparisionErrors,
-  ScreenshotsSuite
-}
+import com.karumi.shot.domain.model.{AppId, Folder, ScreenshotComparisionErrors, ScreenshotsSuite}
 import freemarker.template.{Configuration, Template, TemplateExceptionHandler}
 
 class ExecutionReporter {
@@ -20,8 +15,7 @@ class ExecutionReporter {
     val config = new Configuration(Configuration.VERSION_2_3_23)
     config.setClassForTemplateLoading(getClass, "/templates/")
     config.setDefaultEncoding("UTF-8")
-    config.setTemplateExceptionHandler(
-      TemplateExceptionHandler.RETHROW_HANDLER)
+    config.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER)
     config
   }
 
@@ -30,31 +24,24 @@ class ExecutionReporter {
                            buildFolder: Folder,
                            flavor: String,
                            buildType: String) = {
-    val input = generateRecordTemplateValues(appId, screenshots)
+    val input    = generateRecordTemplateValues(appId, screenshots)
     val template = freeMarkerConfig.getTemplate("recordIndex.ftl")
     resetVerificationReport(flavor, buildType)
-    val reportFolder = buildFolder + Config.recordingReportFolder(
-      flavor,
-      buildType) + "/"
+    val reportFolder = buildFolder + Config.recordingReportFolder(flavor, buildType) + "/"
     writeReport(buildFolder, input, template, reportFolder)
   }
 
-  def generateVerificationReport(
-      appId: AppId,
-      comparision: ScreenshotsComparisionResult,
-      buildFolder: Folder,
-      flavor: String,
-      buildType: String,
-      showOnlyFailingTestsInReports: Boolean = false) = {
-    val input = generateVerificationTemplateValues(
-      appId,
-      comparision,
-      showOnlyFailingTestsInReports)
+  def generateVerificationReport(appId: AppId,
+                                 comparision: ScreenshotsComparisionResult,
+                                 buildFolder: Folder,
+                                 flavor: String,
+                                 buildType: String,
+                                 showOnlyFailingTestsInReports: Boolean = false) = {
+    val input =
+      generateVerificationTemplateValues(appId, comparision, showOnlyFailingTestsInReports)
     val template = freeMarkerConfig.getTemplate("verificationIndex.ftl")
     resetVerificationReport(flavor, buildType)
-    val reportFolder = buildFolder + Config.verificationReportFolder(
-      flavor,
-      buildType) + "/"
+    val reportFolder = buildFolder + Config.verificationReportFolder(flavor, buildType) + "/"
     writeReport(buildFolder, input, template, reportFolder)
   }
 
@@ -70,8 +57,7 @@ class ExecutionReporter {
   }
 
   private def resetVerificationReport(flavor: String, buildType: String) = {
-    val file = new File(
-      Config.verificationReportFolder(flavor, buildType) + "/index.html")
+    val file = new File(Config.verificationReportFolder(flavor, buildType) + "/index.html")
     if (file.exists()) {
       file.delete()
     }
@@ -80,24 +66,21 @@ class ExecutionReporter {
   private def generateRecordTemplateValues(
       appId: AppId,
       screenshots: ScreenshotsSuite): util.Map[String, String] = {
-    val title = s"Record results: $appId"
+    val title         = s"Record results: $appId"
     val numberOfTests = screenshots.size
     val summaryResults =
       s"$numberOfTests screenshot tests recorded."
     val summaryTableBody = generateRecordSummaryTableBody(screenshots)
-    Map("title" -> title,
-        "summaryResult" -> summaryResults,
-        "summaryTableBody" -> summaryTableBody).asJava
+    Map("title" -> title, "summaryResult" -> summaryResults, "summaryTableBody" -> summaryTableBody).asJava
   }
 
-  private def generateRecordSummaryTableBody(
-      screenshots: ScreenshotsSuite): String = {
+  private def generateRecordSummaryTableBody(screenshots: ScreenshotsSuite): String = {
     screenshots
       .map { screenshot: Screenshot =>
-        val testClass = screenshot.testClass
-        val testName = screenshot.testName
+        val testClass          = screenshot.testClass
+        val testName           = screenshot.testName
         val originalScreenshot = "./images/recorded/" + screenshot.name + ".png"
-        val width = (screenshot.screenshotDimension.width * 0.2).toInt
+        val width              = (screenshot.screenshotDimension.width * 0.2).toInt
         "<tr>" +
           s"<th> <p>Test class: $testClass</p>" +
           s"<p>Test name: $testName</p></th>" +
@@ -111,26 +94,24 @@ class ExecutionReporter {
       appId: AppId,
       comparision: ScreenshotsComparisionResult,
       showOnlyFailingTestsInReports: Boolean): util.Map[String, String] = {
-    val title = s"Verification results: $appId"
-    val screenshots = comparision.screenshots
+    val title         = s"Verification results: $appId"
+    val screenshots   = comparision.screenshots
     val numberOfTests = screenshots.size
-    val failedNumber = comparision.errors.size
+    val failedNumber  = comparision.errors.size
     val successNumber = numberOfTests - failedNumber
     val summaryResults =
       s"$numberOfTests screenshot tests executed. $successNumber passed and $failedNumber failed."
-    val summaryTableBody = generateVerificationSummaryTableBody(
-      comparision,
-      showOnlyFailingTestsInReports)
+    val summaryTableBody =
+      generateVerificationSummaryTableBody(comparision, showOnlyFailingTestsInReports)
     val screenshotsTableBody =
       generateScreenshotsTableBody(comparision, showOnlyFailingTestsInReports)
-    Map("title" -> title,
-        "summaryResult" -> summaryResults,
-        "summaryTableBody" -> summaryTableBody,
+    Map("title"                -> title,
+        "summaryResult"        -> summaryResults,
+        "summaryTableBody"     -> summaryTableBody,
         "screenshotsTableBody" -> screenshotsTableBody).asJava
   }
 
-  private def getSortedByResultScreenshots(
-      comparison: ScreenshotsComparisionResult) =
+  private def getSortedByResultScreenshots(comparison: ScreenshotsComparisionResult) =
     comparison.screenshots
       .map { screenshot: Screenshot =>
         val error = findError(screenshot, comparison.errors)
@@ -145,12 +126,12 @@ class ExecutionReporter {
       .map {
         case (screenshot, error) =>
           val isFailedTest = error.isDefined
-          val testClass = screenshot.testClass
-          val testName = screenshot.testName
-          val result = if (isFailedTest) "❌" else "✅"
-          val reason = generateReasonMessage(error)
-          val color = if (isFailedTest) "red-text" else "green-text"
-          val id = screenshot.name.replace(".", "")
+          val testClass    = screenshot.testClass
+          val testName     = screenshot.testName
+          val result       = if (isFailedTest) "❌" else "✅"
+          val reason       = generateReasonMessage(error)
+          val color        = if (isFailedTest) "red-text" else "green-text"
+          val id           = screenshot.name.replace(".", "")
 
           if (showOnlyFailingTestsInReports && isFailedTest || !showOnlyFailingTestsInReports) {
             "<tr>" +
@@ -166,17 +147,16 @@ class ExecutionReporter {
       .mkString("\n")
   }
 
-  private def generateScreenshotsTableBody(
-      comparision: ScreenshotsComparisionResult,
-      showOnlyFailingTestsInReports: Boolean): String = {
+  private def generateScreenshotsTableBody(comparision: ScreenshotsComparisionResult,
+                                           showOnlyFailingTestsInReports: Boolean): String = {
     getSortedByResultScreenshots(comparision)
       .map {
         case (screenshot, error) =>
-          val isFailedTest = error.isDefined
-          val testClass = screenshot.testClass
-          val testName = screenshot.testName
+          val isFailedTest       = error.isDefined
+          val testClass          = screenshot.testClass
+          val testName           = screenshot.testName
           val originalScreenshot = "./images/recorded/" + screenshot.name + ".png"
-          val newScreenshot = "./images/" + screenshot.name + ".png"
+          val newScreenshot      = "./images/" + screenshot.name + ".png"
           val diff = if (error.exists(_.isInstanceOf[DifferentScreenshots])) {
             screenshot.getDiffScreenshotPath("./images/")
           } else {
@@ -184,7 +164,7 @@ class ExecutionReporter {
           }
           val color = if (isFailedTest) "red-text" else "green-text"
           val width = (screenshot.screenshotDimension.width * 0.2).toInt
-          val id = screenshot.name.replace(".", "")
+          val id    = screenshot.name.replace(".", "")
 
           if (showOnlyFailingTestsInReports && isFailedTest || !showOnlyFailingTestsInReports) {
             "<tr>" +
@@ -201,18 +181,16 @@ class ExecutionReporter {
       .mkString("\n")
   }
 
-  private def findError(
-      screenshot: Screenshot,
-      errors: ScreenshotComparisionErrors): Option[ScreenshotComparisonError] =
+  private def findError(screenshot: Screenshot,
+                        errors: ScreenshotComparisionErrors): Option[ScreenshotComparisonError] =
     errors.find {
-      case ScreenshotNotFound(error) => screenshot == error
+      case ScreenshotNotFound(error)             => screenshot == error
       case DifferentImageDimensions(error, _, _) => screenshot == error
-      case DifferentScreenshots(error, _) => screenshot == error
-      case _ => false
+      case DifferentScreenshots(error, _)        => screenshot == error
+      case _                                     => false
     }
 
-  private def generateReasonMessage(
-      error: Option[ScreenshotComparisonError]): String =
+  private def generateReasonMessage(error: Option[ScreenshotComparisonError]): String =
     error
       .map {
         case ScreenshotNotFound(_) =>

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotComposer.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotComposer.scala
@@ -9,23 +9,21 @@ object ScreenshotComposer {
 
   private val tileSize = 512
 
-  private[screenshots] def composeNewScreenshot(
-      screenshot: Screenshot): Image = {
-    val width = screenshot.screenshotDimension.width
+  private[screenshots] def composeNewScreenshot(screenshot: Screenshot): Image = {
+    val width  = screenshot.screenshotDimension.width
     val height = screenshot.screenshotDimension.height
     if (screenshot.recordedPartsPaths.size == 1) {
       Image.fromFile(new File(screenshot.recordedPartsPaths.head))
     } else {
       var composedImage = Image.filled(width, height, Color.Transparent)
-      var partIndex = 0
+      var partIndex     = 0
       for (x <- 0 until screenshot.tilesDimension.width;
            y <- 0 until screenshot.tilesDimension.height) {
-        val partFile = new File(screenshot.recordedPartsPaths(partIndex))
-        val part = Image.fromFile(partFile).awt
+        val partFile  = new File(screenshot.recordedPartsPaths(partIndex))
+        val part      = Image.fromFile(partFile).awt
         val xPosition = x * tileSize
         val yPosition = y * tileSize
-        composedImage =
-          composedImage.overlay(new AwtImage(part), xPosition, yPosition)
+        composedImage = composedImage.overlay(new AwtImage(part), xPosition, yPosition)
         partIndex += 1
       }
       composedImage

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsComparator.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsComparator.scala
@@ -8,16 +8,14 @@ import com.sksamuel.scrimage.Image
 
 class ScreenshotsComparator {
 
-  def compare(screenshots: ScreenshotsSuite,
-              tolerance: Double): ScreenshotsComparisionResult = {
+  def compare(screenshots: ScreenshotsSuite, tolerance: Double): ScreenshotsComparisionResult = {
     val errors =
       screenshots.par.flatMap(compareScreenshot(_, tolerance)).toList
     ScreenshotsComparisionResult(errors, screenshots)
   }
 
-  private def compareScreenshot(
-      screenshot: Screenshot,
-      tolerance: Double): Option[ScreenshotComparisonError] = {
+  private def compareScreenshot(screenshot: Screenshot,
+                                tolerance: Double): Option[ScreenshotComparisonError] = {
     val recordedScreenshotFile = new File(screenshot.recordedScreenshotPath)
     if (!recordedScreenshotFile.exists()) {
       Some(ScreenshotNotFound(screenshot))
@@ -29,14 +27,8 @@ class ScreenshotsComparator {
         val originalDimension =
           Dimension(oldScreenshot.width, oldScreenshot.height)
         val newDimension = Dimension(newScreenshot.width, newScreenshot.height)
-        Some(
-          DifferentImageDimensions(screenshot,
-                                   originalDimension,
-                                   newDimension))
-      } else if (imagesAreDifferent(screenshot,
-                                    oldScreenshot,
-                                    newScreenshot,
-                                    tolerance)) {
+        Some(DifferentImageDimensions(screenshot, originalDimension, newDimension))
+      } else if (imagesAreDifferent(screenshot, oldScreenshot, newScreenshot, tolerance)) {
         Some(DifferentScreenshots(screenshot))
       } else {
         None
@@ -56,9 +48,9 @@ class ScreenshotsComparator {
       val differentPixels =
         oldScreenshotPixels.diff(newScreenshotPixels).length
       val percentageOfDifferentPixels = differentPixels.toDouble / oldScreenshotPixels.length.toDouble
-      val percentageOutOf100 = percentageOfDifferentPixels * 100.0
-      val imagesAreDifferent = percentageOutOf100 >= tolerance
-      val imagesAreConsideredEquals = !imagesAreDifferent
+      val percentageOutOf100          = percentageOfDifferentPixels * 100.0
+      val imagesAreDifferent          = percentageOutOf100 >= tolerance
+      val imagesAreConsideredEquals   = !imagesAreDifferent
       if (imagesAreConsideredEquals && tolerance != Config.defaultTolerance) {
         val screenshotName = screenshot.name
         println(
@@ -68,8 +60,7 @@ class ScreenshotsComparator {
     }
   }
 
-  private def haveSameDimensions(newScreenshot: Image,
-                                 recordedScreenshot: Image): Boolean =
+  private def haveSameDimensions(newScreenshot: Image, recordedScreenshot: Image): Boolean =
     newScreenshot.width == recordedScreenshot.width && newScreenshot.height == recordedScreenshot.height
 
 }

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsDiffGenerator.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsDiffGenerator.scala
@@ -4,19 +4,15 @@ import java.io.File
 
 import com.karumi.shot.base64.Base64Encoder
 import com.karumi.shot.domain.model.ScreenshotComparisionErrors
-import com.karumi.shot.domain.{
-  DifferentScreenshots,
-  ScreenshotsComparisionResult
-}
+import com.karumi.shot.domain.{DifferentScreenshots, ScreenshotsComparisionResult}
 import com.sksamuel.scrimage.Image
 import com.sksamuel.scrimage.composite.RedComposite
 
 class ScreenshotsDiffGenerator(base64Encoder: Base64Encoder) {
 
-  def generateDiffs(
-      comparision: ScreenshotsComparisionResult,
-      outputFolder: String,
-      generateBase64Diff: Boolean): ScreenshotsComparisionResult = {
+  def generateDiffs(comparision: ScreenshotsComparisionResult,
+                    outputFolder: String,
+                    generateBase64Diff: Boolean): ScreenshotsComparisionResult = {
     val updatedErrors: ScreenshotComparisionErrors =
       comparision.errors.par.map {
         case error: DifferentScreenshots =>
@@ -26,17 +22,16 @@ class ScreenshotsDiffGenerator(base64Encoder: Base64Encoder) {
     comparision.copy(errors = updatedErrors)
   }
 
-  private def generateDiff(
-      error: DifferentScreenshots,
-      outputFolder: String,
-      generateBase64Diff: Boolean): DifferentScreenshots = {
-    val screenshot = error.screenshot
+  private def generateDiff(error: DifferentScreenshots,
+                           outputFolder: String,
+                           generateBase64Diff: Boolean): DifferentScreenshots = {
+    val screenshot        = error.screenshot
     val originalImagePath = screenshot.recordedScreenshotPath
-    val newImagePath = screenshot.temporalScreenshotPath
-    val originalImage = Image.fromFile(new File(originalImagePath))
-    val newImage = Image.fromFile(new File(newImagePath))
-    val diff = newImage.composite(new RedComposite(1d), originalImage)
-    val outputFilePath = screenshot.getDiffScreenshotPath(outputFolder)
+    val newImagePath      = screenshot.temporalScreenshotPath
+    val originalImage     = Image.fromFile(new File(originalImagePath))
+    val newImage          = Image.fromFile(new File(newImagePath))
+    val diff              = newImage.composite(new RedComposite(1d), originalImage)
+    val outputFilePath    = screenshot.getDiffScreenshotPath(outputFolder)
     diff.output(outputFilePath)
     if (generateBase64Diff) {
       error.copy(base64Diff = base64Encoder.base64FromFile(outputFilePath))

--- a/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsSaver.scala
+++ b/core/src/main/scala/com/karumi/shot/screenshots/ScreenshotsSaver.scala
@@ -22,17 +22,14 @@ class ScreenshotsSaver {
                               buildType: String,
                               screenshots: ScreenshotsSuite) = {
     deleteOldScreenshots(projectFolder, flavor, buildType)
-    saveScreenshots(
-      screenshots,
-      projectFolder + Config.screenshotsFolderName(flavor, buildType))
+    saveScreenshots(screenshots, projectFolder + Config.screenshotsFolderName(flavor, buildType))
   }
 
   def saveTemporalScreenshots(screenshots: ScreenshotsSuite,
                               projectName: String,
                               reportFolder: String) = {
     deleteOldTemporalScreenshots(projectName)
-    saveScreenshots(screenshots,
-                    Config.screenshotsTemporalRootPath + projectName + "/")
+    saveScreenshots(screenshots, Config.screenshotsTemporalRootPath + projectName + "/")
     deleteFile(reportFolder)
     saveScreenshots(screenshots, reportFolder)
   }
@@ -43,8 +40,7 @@ class ScreenshotsSaver {
                                                destinyFolder: Folder) = {
     val recordedScreenshotsFolder = projectFolder + Config
       .screenshotsFolderName(flavor, buildType)
-    FileUtils.copyDirectory(new File(recordedScreenshotsFolder),
-                            new File(destinyFolder))
+    FileUtils.copyDirectory(new File(recordedScreenshotsFolder), new File(destinyFolder))
     deleteFile(destinyFolder)
   }
 
@@ -55,32 +51,26 @@ class ScreenshotsSaver {
     deleteFile(destinyFolder)
   }
 
-  def removeNonFailingReferenceImages(
-      verificationReferenceImagesFolder: Folder,
-      screenshotsResult: ScreenshotsComparisionResult): Unit =
+  def removeNonFailingReferenceImages(verificationReferenceImagesFolder: Folder,
+                                      screenshotsResult: ScreenshotsComparisionResult): Unit =
     screenshotsResult.correctScreenshots.foreach(screenshot =>
       deleteFile(verificationReferenceImagesFolder + screenshot.fileName))
 
   private def copyFile(screenshot: Screenshot, destinyFolder: Folder): Unit = {
     val existingScreenshot = new File(screenshot.recordedScreenshotPath)
-    FileUtils.copyFile(existingScreenshot,
-                       new File(destinyFolder + existingScreenshot.getName))
+    FileUtils.copyFile(existingScreenshot, new File(destinyFolder + existingScreenshot.getName))
   }
 
   def getScreenshotDimension(projectFolder: String,
                              flavor: String,
                              buildType: String,
                              screenshot: Screenshot): Dimension = {
-    val screenshotPath = projectFolder + Config.pulledScreenshotsFolder(
-      flavor,
-      buildType) + screenshot.name + ".png"
-    val image = Image.fromFile(new File(screenshotPath))
+    val screenshotPath = projectFolder + Config.pulledScreenshotsFolder(flavor, buildType) + screenshot.name + ".png"
+    val image          = Image.fromFile(new File(screenshotPath))
     Dimension(image.width, image.height)
   }
 
-  private def deleteOldScreenshots(projectFolder: Folder,
-                                   flavor: String,
-                                   buildType: String) = {
+  private def deleteOldScreenshots(projectFolder: Folder, flavor: String, buildType: String) = {
     deleteFile(projectFolder + Config.screenshotsFolderName(flavor, buildType))
   }
 

--- a/core/src/main/scala/com/karumi/shot/xml/ScreenshotsSuiteXmlParser.scala
+++ b/core/src/main/scala/com/karumi/shot/xml/ScreenshotsSuiteXmlParser.scala
@@ -15,26 +15,22 @@ object ScreenshotsSuiteXmlParser {
                        temporalScreenshotsFolder: Folder): ScreenshotsSuite = {
     val xmlScreenshots = XML.loadString(xml) \ "screenshot"
     xmlScreenshots.map(
-      parseScreenshot(_,
-                      projectName,
-                      screenshotsFolder,
-                      temporalScreenshotsFolder))
+      parseScreenshot(_, projectName, screenshotsFolder, temporalScreenshotsFolder))
   }
 
-  private def parseScreenshot(
-      xmlNode: Node,
-      projectName: String,
-      screenshotsFolder: Folder,
-      temporalScreenshotsFolder: Folder): Screenshot = {
-    val name = (xmlNode \ "name" head).text.trim
+  private def parseScreenshot(xmlNode: Node,
+                              projectName: String,
+                              screenshotsFolder: Folder,
+                              temporalScreenshotsFolder: Folder): Screenshot = {
+    val name                   = (xmlNode \ "name" head).text.trim
     val recordedScreenshotPath = screenshotsFolder + name + ".png"
     val temporalScreenshotPath = Config.screenshotsTemporalRootPath + projectName + "/" + name + ".png"
-    val testClass = (xmlNode \ "test_class" head).text.trim
-    val testName = (xmlNode \ "test_name" head).text.trim
-    val tileWidth = (xmlNode \ "tile_width" head).text.toInt
-    val tileHeight = (xmlNode \ "tile_height" head).text.toInt
-    val tilesDimension = Dimension(tileWidth, tileHeight)
-    val viewHierarchy = (xmlNode \ "view_hierarchy" head).text.trim
+    val testClass              = (xmlNode \ "test_class" head).text.trim
+    val testName               = (xmlNode \ "test_name" head).text.trim
+    val tileWidth              = (xmlNode \ "tile_width" head).text.toInt
+    val tileHeight             = (xmlNode \ "tile_height" head).text.toInt
+    val tilesDimension         = Dimension(tileWidth, tileHeight)
+    val viewHierarchy          = (xmlNode \ "view_hierarchy" head).text.trim
     val absoluteFileNames =
       (xmlNode \ "absolute_file_name").map(_.text.trim + ".png")
     val relativeFileNames =
@@ -56,18 +52,16 @@ object ScreenshotsSuiteXmlParser {
     )
   }
 
-  def parseScreenshotSize(screenshot: Screenshot,
-                          viewHierarchyContent: String): Screenshot = {
-    val json = parse(viewHierarchyContent)
-    val viewHierarchyNode = json \ "viewHierarchy"
-    val JInt(screenshotLeft) = viewHierarchyNode \ "left"
-    val JInt(screenshotWidth) = viewHierarchyNode \ "width"
-    val JInt(screenshotTop) = viewHierarchyNode \ "top"
+  def parseScreenshotSize(screenshot: Screenshot, viewHierarchyContent: String): Screenshot = {
+    val json                   = parse(viewHierarchyContent)
+    val viewHierarchyNode      = json \ "viewHierarchy"
+    val JInt(screenshotLeft)   = viewHierarchyNode \ "left"
+    val JInt(screenshotWidth)  = viewHierarchyNode \ "width"
+    val JInt(screenshotTop)    = viewHierarchyNode \ "top"
     val JInt(screenshotHeight) = viewHierarchyNode \ "height"
     screenshot.copy(
-      screenshotDimension =
-        Dimension(screenshotLeft.toInt + screenshotWidth.toInt,
-                  screenshotTop.toInt + screenshotHeight.toInt))
+      screenshotDimension = Dimension(screenshotLeft.toInt + screenshotWidth.toInt,
+                                      screenshotTop.toInt + screenshotHeight.toInt))
   }
 
 }

--- a/core/src/test/scala/com/karumi/shot/ShotSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/ShotSpec.scala
@@ -15,23 +15,18 @@ import com.karumi.shot.ui.Console
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-class ShotSpec
-    extends FlatSpec
-    with Matchers
-    with BeforeAndAfter
-    with MockFactory
-    with Resources {
+class ShotSpec extends FlatSpec with Matchers with BeforeAndAfter with MockFactory with Resources {
 
-  private var shot: Shot = _
-  private val adb = mock[Adb]
-  private val files = mock[Files]
-  private val console = mock[Console]
-  private val screenshotsComparator = mock[ScreenshotsComparator]
+  private var shot: Shot               = _
+  private val adb                      = mock[Adb]
+  private val files                    = mock[Files]
+  private val console                  = mock[Console]
+  private val screenshotsComparator    = mock[ScreenshotsComparator]
   private val screenshotsDiffGenerator = mock[ScreenshotsDiffGenerator]
-  private val screenshotsSaver = mock[ScreenshotsSaver]
-  private val reporter = mock[ExecutionReporter]
-  private val consoleReporter = mock[ConsoleReporter]
-  private val envVars = mock[EnvVars]
+  private val screenshotsSaver         = mock[ScreenshotsSaver]
+  private val reporter                 = mock[ExecutionReporter]
+  private val consoleReporter          = mock[ConsoleReporter]
+  private val envVars                  = mock[EnvVars]
 
   before {
     shot = new Shot(adb,
@@ -46,7 +41,7 @@ class ShotSpec
   }
 
   "Shot" should "should delegate screenshots cleaning to Adb" in {
-    val appId: AppId = AppIdMother.anyAppId
+    val appId: AppId   = AppIdMother.anyAppId
     val device: String = "emulator-5554"
     (adb.devices _).expects().returns(List(device))
     (envVars.androidSerial _).expects().returns(None)
@@ -57,12 +52,11 @@ class ShotSpec
   }
 
   it should "pull the screenshots using the project metadata folder and the app id" in {
-    val appId = AppIdMother.anyAppId
-    val device = "emulator-5554"
+    val appId         = AppIdMother.anyAppId
+    val device        = "emulator-5554"
     val projectFolder = ProjectFolderMother.anyProjectFolder
     val expectedScreenshotsFolder = projectFolder + Config
-      .screenshotsFolderName(BuildTypeMother.anyFlavor,
-                             BuildTypeMother.anyBuildType)
+      .screenshotsFolderName(BuildTypeMother.anyFlavor, BuildTypeMother.anyBuildType)
     val expectedOriginalMetadataFile = projectFolder + Config.metadataFileName(
       BuildTypeMother.anyFlavor,
       BuildTypeMother.anyBuildType)
@@ -70,11 +64,9 @@ class ShotSpec
       BuildTypeMother.anyFlavor,
       BuildTypeMother.anyBuildType) + "_" + device
     val expectedComposeOriginalMetadataFile = projectFolder + Config
-      .composeMetadataFileName(BuildTypeMother.anyFlavor,
-                               BuildTypeMother.anyBuildType)
+      .composeMetadataFileName(BuildTypeMother.anyFlavor, BuildTypeMother.anyBuildType)
     val expectedComposeRenamedMetadataFile = projectFolder + Config
-      .composeMetadataFileName(BuildTypeMother.anyFlavor,
-                               BuildTypeMother.anyBuildType) + "_" + device
+      .composeMetadataFileName(BuildTypeMother.anyFlavor, BuildTypeMother.anyBuildType) + "_" + device
     (adb.devices _).expects().returns(List(device))
     (envVars.androidSerial _).expects().returns(None)
 
@@ -85,8 +77,7 @@ class ShotSpec
       .expects(expectedOriginalMetadataFile, expectedRenamedMetadataFile)
       .once()
     (files.rename _)
-      .expects(expectedComposeOriginalMetadataFile,
-               expectedComposeRenamedMetadataFile)
+      .expects(expectedComposeOriginalMetadataFile, expectedComposeRenamedMetadataFile)
       .once()
 
     shot.downloadScreenshots(projectFolder,
@@ -104,7 +95,7 @@ class ShotSpec
   }
 
   it should "should delegate screenshots cleaning to Adb using the specified ANDROID_SERIAL env var" in {
-    val appId: AppId = AppIdMother.anyAppId
+    val appId: AppId    = AppIdMother.anyAppId
     val device1: String = "emulator-5554"
     val device2: String = "emulator-5556"
     (adb.devices _).expects().returns(List(device1, device2))
@@ -116,13 +107,12 @@ class ShotSpec
   }
 
   it should "pull the screenshots using the project metadata folder and the app id from the specified ANDROID_SERIAL env var" in {
-    val appId = AppIdMother.anyAppId
-    val device1 = "emulator-5554"
-    val device2 = "emulator-5556"
+    val appId         = AppIdMother.anyAppId
+    val device1       = "emulator-5554"
+    val device2       = "emulator-5556"
     val projectFolder = ProjectFolderMother.anyProjectFolder
     val expectedScreenshotsFolder = projectFolder + Config
-      .screenshotsFolderName(BuildTypeMother.anyFlavor,
-                             BuildTypeMother.anyBuildType)
+      .screenshotsFolderName(BuildTypeMother.anyFlavor, BuildTypeMother.anyBuildType)
     val expectedOriginalMetadataFile = projectFolder + Config.metadataFileName(
       BuildTypeMother.anyFlavor,
       BuildTypeMother.anyBuildType)
@@ -130,11 +120,9 @@ class ShotSpec
       BuildTypeMother.anyFlavor,
       BuildTypeMother.anyBuildType) + "_" + device2
     val expectedComposeOriginalMetadataFile = projectFolder + Config
-      .composeMetadataFileName(BuildTypeMother.anyFlavor,
-                               BuildTypeMother.anyBuildType)
+      .composeMetadataFileName(BuildTypeMother.anyFlavor, BuildTypeMother.anyBuildType)
     val expectedComposeRenamedFile = projectFolder + Config
-      .composeMetadataFileName(BuildTypeMother.anyFlavor,
-                               BuildTypeMother.anyBuildType) + "_" + device2
+      .composeMetadataFileName(BuildTypeMother.anyFlavor, BuildTypeMother.anyBuildType) + "_" + device2
     (adb.devices _).expects().returns(List(device1, device2))
     (envVars.androidSerial _).expects().returns(Some(device2))
 
@@ -152,7 +140,7 @@ class ShotSpec
   }
 
   it should "should delegate screenshots cleaning to Adb using the devices if ANDROID_SERIAL env var is not valid" in {
-    val appId: AppId = AppIdMother.anyAppId
+    val appId: AppId    = AppIdMother.anyAppId
     val device1: String = "emulator-5554"
     val device2: String = "emulator-5556"
     (adb.devices _).expects().returns(List(device1, device2))

--- a/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/domain/ConfigSpec.scala
@@ -14,21 +14,15 @@ class ConfigSpec extends FlatSpec with Matchers {
   }
 
   it should "save the screenshots into the screenshots folder" in {
-    Config.screenshotsFolderName(
-      BuildTypeMother.anyFlavor,
-      BuildTypeMother.anyBuildType) shouldBe s"/screenshots/${BuildTypeMother.anyFlavor}/${BuildTypeMother.anyBuildType}/"
+    Config.screenshotsFolderName(BuildTypeMother.anyFlavor, BuildTypeMother.anyBuildType) shouldBe s"/screenshots/${BuildTypeMother.anyFlavor}/${BuildTypeMother.anyBuildType}/"
   }
 
   it should "point at the temporal screenshots folder" in {
-    Config.pulledScreenshotsFolder(
-      BuildTypeMother.anyFlavor,
-      BuildTypeMother.anyBuildType) shouldBe s"/screenshots/${BuildTypeMother.anyFlavor}/${BuildTypeMother.anyBuildType}/screenshots-default/"
+    Config.pulledScreenshotsFolder(BuildTypeMother.anyFlavor, BuildTypeMother.anyBuildType) shouldBe s"/screenshots/${BuildTypeMother.anyFlavor}/${BuildTypeMother.anyBuildType}/screenshots-default/"
   }
 
   it should "point at the metadata folder" in {
-    Config.metadataFileName(
-      BuildTypeMother.anyFlavor,
-      BuildTypeMother.anyBuildType) shouldBe s"/screenshots/${BuildTypeMother.anyFlavor}/${BuildTypeMother.anyBuildType}/screenshots-default/metadata.xml"
+    Config.metadataFileName(BuildTypeMother.anyFlavor, BuildTypeMother.anyBuildType) shouldBe s"/screenshots/${BuildTypeMother.anyFlavor}/${BuildTypeMother.anyBuildType}/screenshots-default/metadata.xml"
   }
 
   it should "point at the tmp folder" in {

--- a/core/src/test/scala/com/karumi/shot/mothers/BuildTypeMother.scala
+++ b/core/src/test/scala/com/karumi/shot/mothers/BuildTypeMother.scala
@@ -1,6 +1,6 @@
 package com.karumi.shot.mothers
 
 object BuildTypeMother {
-  val anyFlavor: String = "green"
+  val anyFlavor: String    = "green"
   val anyBuildType: String = "debug"
 }

--- a/core/src/test/scala/com/karumi/shot/xml/ScreenshotsSuiteXmlParserSpec.scala
+++ b/core/src/test/scala/com/karumi/shot/xml/ScreenshotsSuiteXmlParserSpec.scala
@@ -5,10 +5,7 @@ import com.karumi.shot.domain.Config
 import com.karumi.shot.xml.ScreenshotsSuiteXmlParser._
 import org.scalatest.{FlatSpec, Matchers}
 
-class ScreenshotsSuiteXmlParserSpec
-    extends FlatSpec
-    with Matchers
-    with Resources {
+class ScreenshotsSuiteXmlParserSpec extends FlatSpec with Matchers with Resources {
 
   private val anyScreenshotsFolder = "/screenshots/"
   private val anyTemporalScreenshotsFolder =
@@ -16,14 +13,10 @@ class ScreenshotsSuiteXmlParserSpec
   private val anyProjectName = "flowup"
 
   "ScreenshotsSuiteXmlParser" should "return an empty spec if there are no screenshots" in {
-    val xml = testResourceContent(
-      "/screenshots-metadata/empty-screenshots-metadata.xml")
+    val xml = testResourceContent("/screenshots-metadata/empty-screenshots-metadata.xml")
 
     val screenshots =
-      parseScreenshots(xml,
-                       anyProjectName,
-                       anyScreenshotsFolder,
-                       anyTemporalScreenshotsFolder)
+      parseScreenshots(xml, anyProjectName, anyScreenshotsFolder, anyTemporalScreenshotsFolder)
 
     screenshots shouldBe empty
   }
@@ -34,10 +27,7 @@ class ScreenshotsSuiteXmlParserSpec
       testResourceContent("/screenshots-metadata/view-hierarchy.json")
 
     val screenshotsWithoutSize =
-      parseScreenshots(xml,
-                       anyProjectName,
-                       anyScreenshotsFolder,
-                       anyTemporalScreenshotsFolder)
+      parseScreenshots(xml, anyProjectName, anyScreenshotsFolder, anyTemporalScreenshotsFolder)
     val screenshots = screenshotsWithoutSize.map { screenshot =>
       parseScreenshotSize(screenshot, viewHierarchyContent)
     }

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -70,8 +70,7 @@ class ShotPlugin extends Plugin[Project] {
       getAndroidLibraryExtension(project)
     val baseTask =
       project.getTasks
-        .register(Config.defaultTaskName,
-                  classOf[ExecuteScreenshotTestsForEveryFlavor])
+        .register(Config.defaultTaskName, classOf[ExecuteScreenshotTestsForEveryFlavor])
     libraryExtension.getLibraryVariants.all { variant =>
       addTaskToVariant(project, baseTask, variant)
     }
@@ -82,36 +81,29 @@ class ShotPlugin extends Plugin[Project] {
       getAndroidAppExtension(project)
     val baseTask =
       project.getTasks
-        .register(Config.defaultTaskName,
-                  classOf[ExecuteScreenshotTestsForEveryFlavor])
+        .register(Config.defaultTaskName, classOf[ExecuteScreenshotTestsForEveryFlavor])
     appExtension.getApplicationVariants.all { variant =>
       addTaskToVariant(project, baseTask, variant)
     }
   }
 
-  private def addTaskToVariant(
-      project: Project,
-      baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor],
-      variant: BaseVariant) = {
+  private def addTaskToVariant(project: Project,
+                               baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor],
+                               variant: BaseVariant) = {
     val flavor = variant.getMergedFlavor
     checkIfApplicationIdIsConfigured(project, flavor)
     val completeAppId = composeCompleteAppId(variant)
     val appTestId =
       Option(flavor.getTestApplicationId).getOrElse(completeAppId)
     if (variant.getBuildType.getName != "release") {
-      addTasksFor(project,
-                  variant.getFlavorName,
-                  variant.getBuildType,
-                  appTestId,
-                  baseTask)
+      addTasksFor(project, variant.getFlavorName, variant.getBuildType, appTestId, baseTask)
     }
   }
 
   private def composeCompleteAppId(variant: BaseVariant) =
     variant.getApplicationId + ".test"
 
-  private def checkIfApplicationIdIsConfigured(project: Project,
-                                               flavor: ProductFlavor) =
+  private def checkIfApplicationIdIsConfigured(project: Project, flavor: ProductFlavor) =
     if (isAnAndroidLibrary(project) && flavor.getTestApplicationId == null) {
       throw ShotException(
         "Your Android library needs to be configured using an testApplicationId in your build.gradle defaultConfig block.")
@@ -122,12 +114,11 @@ class ShotPlugin extends Plugin[Project] {
     project.getExtensions.add(name, new ShotExtension())
   }
 
-  private def addTasksFor(
-      project: Project,
-      flavor: String,
-      buildType: BuildType,
-      appId: String,
-      baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor]): Unit = {
+  private def addTasksFor(project: Project,
+                          flavor: String,
+                          buildType: BuildType,
+                          appId: String,
+                          baseTask: TaskProvider[ExecuteScreenshotTestsForEveryFlavor]): Unit = {
     val extension =
       project.getExtensions.getByType[ShotExtension](classOf[ShotExtension])
     val instrumentationTask = if (extension.useComposer) {
@@ -137,13 +128,11 @@ class ShotPlugin extends Plugin[Project] {
     }
     val tasks = project.getTasks
     val removeScreenshotsAfterExecution = tasks
-      .register(
-        RemoveScreenshotsTask.name(flavor, buildType, beforeExecution = false),
-        classOf[RemoveScreenshotsTask])
+      .register(RemoveScreenshotsTask.name(flavor, buildType, beforeExecution = false),
+                classOf[RemoveScreenshotsTask])
     val removeScreenshotsBeforeExecution = tasks
-      .register(
-        RemoveScreenshotsTask.name(flavor, buildType, beforeExecution = true),
-        classOf[RemoveScreenshotsTask])
+      .register(RemoveScreenshotsTask.name(flavor, buildType, beforeExecution = true),
+                classOf[RemoveScreenshotsTask])
 
     removeScreenshotsAfterExecution.configure { task =>
       task.setDescription(RemoveScreenshotsTask.description(flavor, buildType))
@@ -159,21 +148,17 @@ class ShotPlugin extends Plugin[Project] {
     }
 
     val downloadScreenshots = tasks
-      .register(DownloadScreenshotsTask.name(flavor, buildType),
-                classOf[DownloadScreenshotsTask])
+      .register(DownloadScreenshotsTask.name(flavor, buildType), classOf[DownloadScreenshotsTask])
     downloadScreenshots.configure { task =>
-      task.setDescription(
-        DownloadScreenshotsTask.description(flavor, buildType))
+      task.setDescription(DownloadScreenshotsTask.description(flavor, buildType))
       task.flavor = flavor
       task.buildType = buildType
       task.appId = appId
     }
     val executeScreenshot = tasks
-      .register(ExecuteScreenshotTests.name(flavor, buildType),
-                classOf[ExecuteScreenshotTests])
+      .register(ExecuteScreenshotTests.name(flavor, buildType), classOf[ExecuteScreenshotTests])
     executeScreenshot.configure { task =>
-      task.setDescription(
-        ExecuteScreenshotTests.description(flavor, buildType))
+      task.setDescription(ExecuteScreenshotTests.description(flavor, buildType))
       task.flavor = flavor
       task.buildType = buildType
       task.appId = appId

--- a/shot/src/main/scala/com/karumi/shot/exceptions/ShotException.scala
+++ b/shot/src/main/scala/com/karumi/shot/exceptions/ShotException.scala
@@ -1,5 +1,4 @@
 package com.karumi.shot.exceptions
 
-case class ShotException(private val message: String,
-                         private val cause: Throwable = None.orNull)
+case class ShotException(private val message: String, private val cause: Throwable = None.orNull)
     extends RuntimeException(message, cause)

--- a/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
+++ b/shot/src/main/scala/com/karumi/shot/tasks/Tasks.scala
@@ -16,10 +16,10 @@ import org.gradle.api.{DefaultTask, GradleException}
 import org.gradle.api.tasks.TaskAction
 
 abstract class ShotTask extends DefaultTask {
-  var appId: String = _
-  var flavor: String = _
+  var appId: String        = _
+  var flavor: String       = _
   var buildType: BuildType = _
-  private val console = new Console
+  private val console      = new Console
   protected val shot: Shot =
     new Shot(
       new Adb,
@@ -60,13 +60,13 @@ class ExecuteScreenshotTests extends ShotTask {
       .getByType[ShotExtension](classOf[ShotExtension])
       .tolerance
     val recordScreenshots = project.hasProperty("record")
-    val printBase64 = project.hasProperty("printBase64")
+    val printBase64       = project.hasProperty("printBase64")
     val showOnlyFailingTestsInReports = project.getExtensions
       .getByType[ShotExtension](classOf[ShotExtension])
       .showOnlyFailingTestsInReports
     val projectFolder = project.getProjectDir.getAbsolutePath
-    val projectName = project.getName
-    val buildFolder = project.getBuildDir.getAbsolutePath
+    val projectName   = project.getName
+    val buildFolder   = project.getBuildDir.getAbsolutePath
     if (recordScreenshots) {
       shot.recordScreenshots(appId,
                              buildFolder,


### PR DESCRIPTION
### :pushpin: References
* **Issue:** none
* **Related pull-requests:** #215

### :tophat: What is the goal?
As requested in #215 I extracted `scalafmt` bump to a separate PR

### How is it being implemented?
I bumped scalafmt plugin to the most recent version and then executed `./gradlew scalafmtAll`. Bumping the dependency should reduce configuration time, as the new plugin doesn't download files from the internet at the configuraton time.

### How can it be tested?
If it passes build and tests it should be fine I guess? No behavior changes are expected.
