### PR TITLE
Support passing `runInstrumentation` flag as gradle argument

### DIFF
--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -222,7 +222,7 @@ class ShotPlugin extends Plugin[Project] {
 
   private def runInstrumentation(project: Project, extension: ShotExtension): Boolean = {
     val property = project.findProperty("runInstrumentation").asInstanceOf[String]
-    
+
     if (property != null) {
       if (Try(property.toBoolean).getOrElse(null) == null) {
         throw ShotException("runInstrumentation value must be true|false")

--- a/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
+++ b/shot/src/main/scala/com/karumi/shot/ShotPlugin.scala
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.{Plugin, Project}
 
+import scala.util.Try
 class ShotPlugin extends Plugin[Project] {
 
   private val console = new Console
@@ -182,7 +183,7 @@ class ShotPlugin extends Plugin[Project] {
       task.appId = appId
     }
 
-    if (extension.runInstrumentation) {
+    if (runInstrumentation(project, extension)) {
       executeScreenshot.configure { task =>
         task.dependsOn(instrumentationTaskName)
         task.dependsOn(downloadScreenshots)
@@ -217,6 +218,20 @@ class ShotPlugin extends Plugin[Project] {
       .configure { config =>
         config.extendsFrom(shotConfig)
       }
+  }
+
+  private def runInstrumentation(project: Project, extension: ShotExtension): Boolean = {
+    val property = project.findProperty("runInstrumentation").asInstanceOf[String]
+    
+    if (property != null) {
+      if (Try(property.toBoolean).getOrElse(null) == null) {
+        throw ShotException("runInstrumentation value must be true|false")
+      }
+
+      return property.toBoolean
+    }
+
+    extension.runInstrumentation
   }
 
   private def isAnAndroidLibrary(project: Project): Boolean =


### PR DESCRIPTION
Will allow overriding the configuration set in the gradle file with the commandline argument. 

e.g ./gradlew executeScreenshotTests -PrunInstrumentation=false

### :pushpin: References
* **Issue:** Fixes #228 

### :tophat: What is the goal?

Allow toggling the `runInstrumentation` property from the commandline
### How is it being implemented?

Check the gradle properties before defaulting to the usual config.

### How can it be tested?

Can't see a way of writing any tests for this with the current test suite. Not very familiar with scala or with gradle plugins though so I'm happy to look at this again if I'm missing something.

