### PR TITLE
Remove freemarker.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.12.13'
     implementation 'org.scala-lang.modules:scala-xml_2.12:1.3.0'
     implementation 'com.sksamuel.scrimage:scrimage-core_2.12:2.1.8'
-    implementation 'org.freemarker:freemarker:2.3.31'
     implementation 'io.github.bitstorm:tinyzip-core:1.0.0'
     implementation 'org.json4s:json4s-native_2.12:3.6.11'
     implementation 'org.json4s:json4s-jackson_2.12:3.6.11'

--- a/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
+++ b/core/src/main/scala/com/karumi/shot/reports/ExecutionReporter.scala
@@ -65,8 +65,8 @@ class ExecutionReporter {
       s"$numberOfTests screenshot tests recorded."
     val summaryTableBody = generateRecordSummaryTableBody(screenshots)
     recordIndexTemplate(
-      title            = title,
-      summaryResult    = summaryResults,
+      title = title,
+      summaryResult = summaryResults,
       summaryTableBody = summaryTableBody
     )
   }
@@ -104,9 +104,9 @@ class ExecutionReporter {
     val screenshotsTableBody =
       generateScreenshotsTableBody(comparision, showOnlyFailingTestsInReports)
     verificationIndexTemplate(
-      title                = title,
-      summaryResult        = summaryResults,
-      summaryTableBody     = summaryTableBody,
+      title = title,
+      summaryResult = summaryResults,
+      summaryTableBody = summaryTableBody,
       screenshotsTableBody = screenshotsTableBody
     )
   }
@@ -147,7 +147,7 @@ class ExecutionReporter {
       .mkString("\n")
   }
 
-    private def generateScreenshotsTableBody(
+  private def generateScreenshotsTableBody(
       comparision: ScreenshotsComparisionResult,
       showOnlyFailingTestsInReports: Boolean
   ): String = {

--- a/core/src/main/scala/com/karumi/shot/templates/RecordIndexTemplate.scala
+++ b/core/src/main/scala/com/karumi/shot/templates/RecordIndexTemplate.scala
@@ -1,3 +1,13 @@
+package com.karumi.shot.templates
+
+object RecordIndexTemplate {
+  def recordIndexTemplate(
+      title: String,
+      summaryResult: String,
+      summaryTableBody: String
+  ): String = {
+    // language=HTML
+    s"""
 <!doctype html>
 <html>
 <head>
@@ -19,7 +29,7 @@
 <body>
 <nav>
     <div class="nav-wrapper indigo darken-3">
-        <a href="#" class="brand-logo left">${title}</a>
+        <a href="#" class="brand-logo left">$title</a>
         <ul id="nav-mobile" class="right hide-on-med-and-down">
             <li><a href="https://github.com/karumi/shot">Shot Documentation</a></li>
         </ul>
@@ -29,14 +39,14 @@
     <div class="section">
         <table class="highlight responsive-table">
             <thead>
-            <h5 class="indigo-text darken-3">Shot record results: ${summaryResult}</h5>
+            <h5 class="indigo-text darken-3">Shot record results: $summaryResult</h5>
             <tr>
                 <th>Test name</th>
                 <th>Screenshot</th>
             </tr>
             </thead>
             <tbody>
-            ${summaryTableBody}
+            $summaryTableBody
             </tbody>
         </table>
     </div>
@@ -77,3 +87,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
 </body>
 </html>
+"""
+  }
+}

--- a/core/src/main/scala/com/karumi/shot/templates/VerificationIndexTemplate.scala
+++ b/core/src/main/scala/com/karumi/shot/templates/VerificationIndexTemplate.scala
@@ -1,3 +1,14 @@
+package com.karumi.shot.templates
+
+object VerificationIndexTemplate {
+  def verificationIndexTemplate(
+      title: String,
+      summaryResult: String,
+      summaryTableBody: String,
+      screenshotsTableBody: String
+  ): String = {
+    // language=HTML
+    s"""
 <!doctype html>
 <html>
 <head>
@@ -19,7 +30,7 @@
 <body>
 <nav>
     <div class="nav-wrapper indigo darken-3">
-        <a href="#" class="brand-logo left">${title}</a>
+        <a href="#" class="brand-logo left">$title</a>
         <ul id="nav-mobile" class="right hide-on-med-and-down">
             <li><a href="https://github.com/karumi/shot">Shot Documentation</a></li>
         </ul>
@@ -29,7 +40,7 @@
     <div class="section">
         <table class="highlight responsive-table">
             <thead>
-            <h5 class="indigo-text darken-3">Shot verification results: ${summaryResult}</h5>
+            <h5 class="indigo-text darken-3">Shot verification results: $summaryResult</h5>
             <tr>
                 <th>Result</th>
                 <th>Test name</th>
@@ -37,7 +48,7 @@
             </tr>
             </thead>
             <tbody>
-            ${summaryTableBody}
+            $summaryTableBody
             </tbody>
         </table>
     </div>
@@ -54,7 +65,7 @@
             </tr>
             </thead>
             <tbody>
-            ${screenshotsTableBody}
+            $screenshotsTableBody
             </tbody>
         </table>
     </div>
@@ -95,3 +106,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
 </body>
 </html>
+"""
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/Karumi/Shot/issues/231

### :pushpin: References
* **Issue:** #231

### :tophat: What is the goal?

Fixes  gradle config cache issue caused by freemarker. 

### How is it being implemented?

Remove Freemarker and just use Scala String interpolation. 

### How can it be tested?

Behavior should not change other than fixing the config cache warning when using this plugin. 