### PR TITLE
Add focus cleaner

### DIFF
--- a/shot-android/src/main/java/com/karumi/shot/FocusCleaner.kt
+++ b/shot-android/src/main/java/com/karumi/shot/FocusCleaner.kt
@@ -1,0 +1,15 @@
+package com.karumi.shot
+
+import android.view.View
+
+interface FocusCleaner {
+
+    var focusTargetView: View?
+
+    fun setFocusOnTargetView(view: View) {
+        focusTargetView?.run {
+            view.filterChildrenViews { child -> child.isFocusable }.map { it.clearFocus() }
+            requestFocusFromTouch()
+        }
+    }
+}

--- a/shot-android/src/main/java/com/karumi/shot/FocusCleaner.kt
+++ b/shot-android/src/main/java/com/karumi/shot/FocusCleaner.kt
@@ -4,12 +4,29 @@ import android.view.View
 
 interface FocusCleaner {
 
-    var focusTargetView: View?
+    sealed class FocusViewIdentifier {
+        class FocusById(val id: Int?) : FocusViewIdentifier()
+        class FocusByTag(val tag: Any?) : FocusViewIdentifier()
+    }
+
+    private fun View.meetsFocusCondition(focusViewIdentifier: FocusViewIdentifier): Boolean =
+        when (focusViewIdentifier) {
+            is FocusViewIdentifier.FocusById -> focusViewIdentifier.id == id
+            is FocusViewIdentifier.FocusByTag -> focusViewIdentifier.tag == tag
+        }
+
+    val focusTargetView: FocusViewIdentifier?
+        get() = null
 
     fun setFocusOnTargetView(view: View) {
         focusTargetView?.run {
-            view.filterChildrenViews { child -> child.isFocusable }.map { it.clearFocus() }
-            requestFocusFromTouch()
+            view.filterChildrenViews { child -> child.isFocusable }.forEach { it.clearFocus() }
+
+            val focusedView =
+                view.filterChildrenViews { child -> child.meetsFocusCondition(this) }
+                    .firstOrNull()
+
+            focusedView?.requestFocusFromTouch()
         }
     }
 }

--- a/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
+++ b/shot-android/src/main/java/com/karumi/shot/ScreenshotTest.kt
@@ -29,7 +29,7 @@ import com.karumi.shot.compose.ComposeScreenshotRunner
 import com.karumi.shot.compose.ScreenshotMetadata
 import java.lang.IllegalStateException
 
-interface ScreenshotTest {
+interface ScreenshotTest : FocusCleaner {
 
     private val context: Context get() = getInstrumentation().targetContext
 
@@ -55,6 +55,7 @@ interface ScreenshotTest {
         val view = activity.findViewById<View>(android.R.id.content)
 
         if (heightInPx == null && widthInPx == null) {
+            setFocusOnTargetView(view)
             disableFlakyComponentsAndWaitForIdle(view)
             takeActivitySnapshot(activity, name)
         } else {
@@ -92,6 +93,7 @@ interface ScreenshotTest {
     ) = compareScreenshot(view = holder.itemView, heightInPx = heightInPx, widthInPx = widthInPx, name = name)
 
     fun compareScreenshot(view: View, heightInPx: Int? = null, widthInPx: Int? = null, name: String? = null) {
+        setFocusOnTargetView(view)
         disableFlakyComponentsAndWaitForIdle(view)
 
         val context = getInstrumentation().targetContext


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #109 

### :tophat: What is the goal?
Make the focus consistent when taking Screenshots

### How is it being implemented?
In a separated file as interface, which SnapshotTest inherits from.
In order to use it in a test, the user has to define the value of the `focusedTargetView` at any point in its test before calling `compareScreenshot(view)`

### How can it be tested?
One could create a screenshot with a lot of EditTexts, and do `focusedTargetView = editTextThatWillGetTheFocus` before taking the snapshot.